### PR TITLE
add script type to examples

### DIFF
--- a/examples/decorator_count_exceptions.py
+++ b/examples/decorator_count_exceptions.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 
 .. code-block:: python

--- a/examples/decorator_inprogress.py
+++ b/examples/decorator_inprogress.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 
 .. code-block:: python

--- a/examples/decorator_timer.py
+++ b/examples/decorator_timer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 Usage:
 

--- a/examples/example-metrics.py
+++ b/examples/example-metrics.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 This example implements an example application that includes an aioprometheus
 based metrics collecting and exporting capability as well as a client function


### PR DESCRIPTION
fixes to apply correct code syntax highlighting to examples scripts when used in docs.