### PR TITLE
return binary formatter as optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lib/
 lib64/
 parts/
 sdist/
+dist/
 var/
 *.egg-info/
 .installed.cfg
@@ -87,6 +88,7 @@ ENV/
 # Rope project settings
 .ropeproject
 
-pyrobuf
-prometheus_metrics_proto.*
+# mypy artefacts
+.mypy_cache
+
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # where the python command links to the Python3.6 executable.
 
 .PHONY: check_types clean clean.scrub coverage docs dist help
-.PHONY: sdist style style.fix test test.verbose
+.PHONY: style style.fix test test.verbose
 
 # Do not remove this block. It is used by the 'help' rule when
 # constructing the help output.
@@ -64,7 +64,7 @@ style.fix:
 
 # help: check_types                    - check type hint annotations
 check_types:
-	@MYPYPATH=$VIRTUAL_ENV/lib/python3.5/site-packages mypy -p aioprometheus --fast-parser --ignore-missing-imports
+	@MYPYPATH=$VIRTUAL_ENV/lib/python*/site-packages mypy -p aioprometheus --ignore-missing-imports
 
 
 # help: docs                           - generate project documentation
@@ -77,17 +77,17 @@ docs: coverage
 
 # help: dist                           - create a source distribution package
 dist: clean
-	@python setup.py sdist
+	@python setup.py bdist_wheel
 
 
 # help: dist.test                      - test a source distribution package
 dist.test: dist
-	@cd dist && ./test.bash ./aioprometheus-*.tar.gz
+	@cd dist && ../tests/test.bash ./aioprometheus-*-py3-none-any.whl
 
 
 # help: dist.upload                     - upload a source distribution package
 dist.upload: clean
-	@python setup.py sdist upload
+	@twine upload dist/aioprometheus-*-py3-none-any.whl
 
 
 # Keep these lines at the end of the file to retain nice help

--- a/README.rst
+++ b/README.rst
@@ -27,11 +27,11 @@ The standard installation of aioprometheus provides metrics in the text
 format. aioprometheus can encode metrics into the binary format too but it
 requires the optional ``aioprometheus-binary-format`` package to also
 be installed. If you want to make use of the binary metrics encoder you will
-need to install ``aioprometheus-binary-format`` manually.
+need to install ``prometheus-metrics-proto`` separately.
 
 .. code-block:: console
 
-    $ pip install aioprometheus-binary-format
+    $ pip install prometheus-metrics-proto
 
 
 Example

--- a/aioprometheus/__init__.py
+++ b/aioprometheus/__init__.py
@@ -9,4 +9,4 @@ from .registry import Registry, CollectorRegistry
 from .service import Service
 
 
-__version__ = "17.04.08"
+__version__ = "17.06.01"

--- a/aioprometheus/formats/__init__.py
+++ b/aioprometheus/formats/__init__.py
@@ -3,7 +3,7 @@ import importlib.util
 from .base import IFormatter
 from .text import TextFormatter
 
-binary_format_spec = importlib.util.find_spec("aioprometheus_binary_format")
-binary_format_available = binary_format_spec is not None
+prometheus_metrics_proto_lib = importlib.util.find_spec("prometheus_metrics_proto")
+binary_format_available = prometheus_metrics_proto_lib is not None
 if binary_format_available:
-    from aioprometheus_binary_format import BinaryFormatter
+    from .binary import BinaryFormatter

--- a/aioprometheus/formats/binary.py
+++ b/aioprometheus/formats/binary.py
@@ -1,0 +1,217 @@
+''' This module implements a Prometheus metrics binary formatter '''
+
+from .base import IFormatter
+from ..collectors import Counter, Gauge, Summary, Histogram
+from typing import cast, Callable, Dict, List, Tuple, Union
+
+# imports only used for type annotations
+from ..registry import CollectorRegistry
+
+from ..formats import binary_format_available
+if binary_format_available:
+    import pyrobuf_util
+    import prometheus_metrics_proto as pmp  # type: ignore
+
+# typing aliases
+LabelsType = Dict[str, str]
+NumericValueType = Union[int, float]
+SummaryDictKeyType = Union[float, str]  # e.g. sum, 0.25, etc
+SummaryDictType = Dict[SummaryDictKeyType, NumericValueType]
+HistogramDictKeyType = Union[float, str]  # e.g. sum, 0.25, etc
+HistogramDictType = Dict[HistogramDictKeyType, NumericValueType]
+CollectorsType = Union[Counter, Gauge, Histogram, Summary]
+MetricValueType = Union[float, SummaryDictType, HistogramDictType]
+MetricTupleType = Tuple[LabelsType, MetricValueType]
+FormatterFuncType = Callable[[MetricTupleType, str, LabelsType], pmp.Metric]
+
+
+class BinaryFormatter(IFormatter):
+    ''' This formatter encodes into the Protocol Buffers binary format '''
+
+    def __init__(self, timestamp: bool = False) -> None:
+        '''
+        :param timestamp: a boolean flag that when True will add a timestamp
+          to metric.
+        '''
+        self.timestamp = timestamp
+        self._headers = {
+            'Content-Type': "application/vnd.google.protobuf; "
+                            "proto=io.prometheus.client.MetricFamily; "
+                            "encoding=delimited"}
+
+    def get_headers(self) -> Dict[str, str]:
+        return self._headers
+
+    def _create_labels(self, labels: LabelsType) -> List[pmp.LabelPair]:
+        ''' Return a list of LabelPair objects for each label. '''
+        return [
+            pmp.LabelPair(name=k, value=str(v)) for k, v in labels.items()]
+
+    def _format_counter(self,
+                        # counter: Tuple[LabelsType, ValueType],
+                        counter: MetricTupleType,
+                        name: str,
+                        const_labels: LabelsType) -> pmp.Metric:
+        '''
+        :param counter: a 2-tuple containing labels and the counter value.
+        :param labels: a dict of labels for a metric.
+        :param const_labels: a dict of constant labels to be associated with
+          the metric.
+        '''
+        counter_labels, counter_value = counter
+        labels = self._unify_labels(counter_labels, const_labels, ordered=True)
+        pb_labels = self._create_labels(labels)
+
+        pb_counter = pmp.Counter(value=counter_value)
+
+        pb_metric = pmp.Metric(label=pb_labels, counter=pb_counter)
+        if self.timestamp:
+            pb_metric.timestamp_ms = self._get_timestamp()
+
+        return pb_metric
+
+    def _format_gauge(self,
+                      gauge: MetricTupleType,
+                      name: str,
+                      const_labels: LabelsType) -> pmp.Metric:
+        '''
+        :param gauge: a 2-tuple containing labels and the gauge value.
+        :param labels: a dict of labels for a metric.
+        :param const_labels: a dict of constant labels to be associated with
+          the metric.
+        '''
+        gauge_labels, gauge_value = gauge
+        labels = self._unify_labels(gauge_labels, const_labels, ordered=True)
+        pb_labels = self._create_labels(labels)
+
+        pb_gauge = pmp.Gauge(value=gauge_value)
+
+        pb_metric = pmp.Metric(label=pb_labels, gauge=pb_gauge)
+        if self.timestamp:
+            pb_metric.timestamp_ms = self._get_timestamp()
+        return pb_metric
+
+    def _format_summary(self,
+                        summary: MetricTupleType,
+                        name: str,
+                        const_labels: LabelsType) -> pmp.Metric:
+        '''
+        :param summary: a 2-tuple containing labels and a dict representing
+          the summary value. The dict contains keys for each quantile as
+          well as the sum and count fields.
+        :param labels: a dict of labels for a metric.
+        :param const_labels: a dict of constant labels to be associated with
+          the metric.
+        '''
+
+        summary_labels, summary_value_dict = summary
+        # typing check, no runtime behaviour.
+        summary_value_dict = cast(SummaryDictType, summary_value_dict)
+        labels = self._unify_labels(summary_labels, const_labels, ordered=True)
+        pb_labels = self._create_labels(labels)
+
+        pb_quantiles = []
+        for k, v in summary_value_dict.items():
+            if not isinstance(k, str):
+                pb_quantile = pmp.Quantile(quantile=k, value=v)
+                pb_quantiles.append(pb_quantile)
+
+        pb_summary = pmp.Summary(
+            sample_count=summary_value_dict['count'],
+            sample_sum=summary_value_dict['sum'],
+            quantile=pb_quantiles)
+
+        pb_metric = pmp.Metric(label=pb_labels, summary=pb_summary)
+        if self.timestamp:
+            pb_metric.timestamp_ms = self._get_timestamp()
+
+        return pb_metric
+
+    def _format_histogram(self,
+                          histogram: MetricTupleType,
+                          name: str,
+                          const_labels: LabelsType) -> pmp.Metric:
+        '''
+        :param histogram: a 2-tuple containing labels and a dict representing
+          the histogram value. The dict contains keys for each bucket as
+          well as the sum and count fields.
+        :param labels: a dict of labels for a metric.
+        :param const_labels: a dict of constant labels to be associated with
+          the metric.
+        '''
+        histogram_labels, histogram_value_dict = histogram
+        # typing check, no runtime behaviour.
+        histogram_value_dict = cast(HistogramDictType, histogram_value_dict)
+        labels = self._unify_labels(
+            histogram_labels, const_labels, ordered=True)
+        pb_labels = self._create_labels(labels)
+
+        pb_buckets = []
+        for k, v in histogram_value_dict.items():
+            if not isinstance(k, str):
+                pb_bucket = pmp.Bucket(cumulative_count=v, upper_bound=k)
+                pb_buckets.append(pb_bucket)
+
+        pb_histogram = pmp.Histogram(
+            sample_count=histogram_value_dict['count'],
+            sample_sum=histogram_value_dict['sum'],
+            bucket=pb_buckets)
+
+        pb_metric = pmp.Metric(label=pb_labels, histogram=pb_histogram)
+        if self.timestamp:
+            pb_metric.timestamp_ms = self._get_timestamp()
+
+        return pb_metric
+
+    def marshall_collector(self,
+                           collector: CollectorsType) -> pmp.MetricFamily:
+        '''
+        Marshalls a collector into :class:`MetricFamily` object representing
+        the metrics in the collector.
+
+        :return: a :class:`MetricFamily` object
+        '''
+        exec_method = None  # type: FormatterFuncType
+        if isinstance(collector, Counter):
+            metric_type = pmp.COUNTER
+            exec_method = self._format_counter
+        elif isinstance(collector, Gauge):
+            metric_type = pmp.GAUGE
+            exec_method = self._format_gauge
+        elif isinstance(collector, Summary):
+            metric_type = pmp.SUMMARY
+            exec_method = self._format_summary
+        elif isinstance(collector, Histogram):
+            metric_type = pmp.HISTOGRAM
+            exec_method = self._format_histogram
+        else:
+            raise TypeError("Not a valid object format")
+
+        pb_metrics = []
+
+        for i in collector.get_all():
+            i = cast(MetricTupleType, i)  # typing check, no runtime behaviour.
+            r = exec_method(i, collector.name, collector.const_labels)
+            pb_metrics.append(r)
+
+        pb_metric_family = pmp.MetricFamily(
+            name=collector.name, help=collector.doc,
+            type=metric_type, metric=pb_metrics)
+
+        return pb_metric_family
+
+    def marshall(self, registry: CollectorRegistry) -> bytes:
+        ''' Marshall the collectors in the registry into binary protocol
+        buffer format.
+
+        The Prometheus metrics parser expects each metric (MetricFamily) to
+        be prefixed with a varint containing the size of the encoded metric.
+
+        :returns: bytes
+        '''
+        payload = []
+        for i in registry.get_all():
+            encoded_metric = self.marshall_collector(i).SerializeToString()
+            length = pyrobuf_util.to_varint(len(encoded_metric))
+            payload.append(length + encoded_metric)
+        return b"".join(payload)

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,3 +1,0 @@
-aioprometheus-*/
-aioprometheus-*.tar.gz
-test_venv/

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -66,7 +66,11 @@ Install the developmental dependencies using ``pip``.
 .. code-block:: console
 
     $ cd aioprometheus
+    $ pip install pip -U
     $ pip install -r requirements.dev.txt
+
+Some rules in the convenience Makefile only work if the dependencies have been
+installed, such as **dist**, **style**, etc.
 
 
 Install aioprometheus
@@ -80,18 +84,19 @@ that any changes take effect immediately.
 
     $ pip install -e .
 
+
 Install optional binary formatter
 +++++++++++++++++++++++++++++++++
 
-If you want to make use of the binary formatter it must be installed
-separately.
+If you want to make use of the binary formatter then a separate package that
+provides the Google Protocol Buffer codec must be installed separately.
 
 .. code-block:: console
 
-    $ pip install aioprometheus-binary-format
+    $ pip install prometheus-metrics-proto
 
-This command will install the ``aioprometheus_binary_format`` module
-that aioprometheus can detect and make use of.
+This command will build and install the ``prometheus_metrics_proto`` extension
+module that aioprometheus can then use to provide metrics in the binary format.
 
 
 Test
@@ -122,7 +127,7 @@ package too.
 .. note::
 
     A number of tests may be skipped if you don't have the optional
-    ``aioprometheus-binary-format`` package installed.
+    ``prometheus-metrics-proto`` package installed.
 
 
 Type Annotations
@@ -132,7 +137,7 @@ The code base has been updated with type annotations. These provide helpful
 gradual typing information that can improve how easily the code is understood
 and which helps with any future enhancements.
 
-The type annotations checker ``mypy`` currently runs cleanly with no warnings.
+The type annotations checker ``mypy`` should run cleanly with no warnings.
 
 Use the Makefile convenience rule to check no issues are reported.
 
@@ -194,7 +199,9 @@ The following steps are used to make a new software release:
 - Ensure that the version label in ``__init__.py`` is correct. It must comply
   with the :ref:`version-label` scheme.
 
-- Create the distribution
+- Create the distribution. This project produces an artefact called a pure
+  Python wheel. Unlike a Universal wheel a pure Python wheel does not natively
+  support both Python2 and Python3. Only Python3 is supported by this package.
 
   .. code-block:: console
 
@@ -202,14 +209,14 @@ The following steps are used to make a new software release:
 
 - Test distribution in ``dist/`` directory. This involves creating a virtual
   environment, installing the source distribution in it and running the tests.
-  These steps have been captured for convenience in the ``dist/test.bash``
-  helper script. The script takes the distribution archive as its only
-  argument.
+  These steps have been captured for convenience in the
+  ``tests/test_dist.bash`` helper script. The script takes the distribution
+  archive as its only argument.
 
   .. code-block:: console
 
       cd dist
-      ./test.bash aioprometheus-16.06.01.tar.gz
+      ../tests/test_dist.bash aioprometheus-17.6.1-py3-none-any.whl
       cd ..
 
 - Upload to PyPI using

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -19,15 +19,15 @@ to install it.
 Install optional binary formatter
 +++++++++++++++++++++++++++++++++
 
-If you want to make use of the binary formatter it must be installed
-separately.
+If you want to make use of the binary formatter then a separate package that
+provides the Google Protocol Buffer codec must be installed separately.
 
 .. code-block:: console
 
-    $ pip install aioprometheus-binary-format
+    $ pip install prometheus-metrics-proto
 
-This command will install the ``aioprometheus_binary_format`` module
-that aioprometheus can detect and make use of.
+This command will build and install the ``prometheus_metrics_proto`` extension
+module that aioprometheus can then use to provide metrics in the binary format.
 
 
 Instrumenting

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,3 +5,5 @@ sphinx>=1.4.4
 coverage>=4.1
 mypy
 typed_ast>=0.5.5
+twine
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==0.21.6
+aiohttp
 quantile-python>=1.1

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,5 @@ if __name__ == "__main__":
             "Natural Language :: English",
             "Operating System :: OS Independent",
             "Programming Language :: Python :: 3.6",
+            "Topic :: Software Development :: Libraries :: Python Modules",
             "Topic :: System :: Monitoring"])

--- a/tests/test_dist.sh
+++ b/tests/test_dist.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env bash
 
 if [ -z "$1" ]; then
-  echo "usage: $0 aioprometheus-YY.MM.MICRO.tar.gz"
+  echo "usage: $0 aioprometheus-YY.MM.MICRO-py3-none-any.whl"
   exit
 fi
 
 RELEASE_ARCHIVE="$1"
-RELEASE_DIR=`echo $RELEASE_ARCHIVE | sed -e "s/\.tar\.gz//g"`
 
 echo "Release archive: $RELEASE_ARCHIVE"
-echo "Release directory: $RELEASE_DIR"
 
 echo "Removing any old artefacts"
-rm -rf $RELEASE_DIR
 rm -rf test_venv
 
 echo "Creating test virtual environment"
@@ -25,13 +22,12 @@ echo "Upgrading pip"
 pip install pip --upgrade
 
 echo "Installing $RELEASE_ARCHIVE"
-tar xf $RELEASE_ARCHIVE
-cd $RELEASE_DIR
-pip install .
+pip install $RELEASE_ARCHIVE
 
 echo "Running tests"
-make test
 cd ..
+make test
+
 
 echo "Exiting test virtual environment"
 deactivate

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -12,16 +12,13 @@ from aioprometheus import (
     Summary)
 from aioprometheus.test_utils import AsyncioTestCase
 
-TEST_PORT = 61423
-TEST_HOST = "127.0.0.1"
-
 
 class TestTextExporter(AsyncioTestCase):
 
     async def setUp(self):
         self.registry = Registry()
         self.server = Service(registry=self.registry, loop=self.loop)
-        await self.server.start(addr=TEST_HOST, port=TEST_PORT)
+        await self.server.start(addr="127.0.0.1")
         self.metrics_url = self.server.url
 
     async def tearDown(self):

--- a/tests/test_formats_binary.py
+++ b/tests/test_formats_binary.py
@@ -3,8 +3,7 @@ import time
 import unittest
 
 from aioprometheus import (
-    Collector, Counter, Gauge, Histogram, Summary,
-    Registry)
+    Collector, Counter, Gauge, Summary, Registry)
 from aioprometheus.formats import binary_format_available
 if binary_format_available:
     from aioprometheus.formats import BinaryFormatter


### PR DESCRIPTION
This merge request returns the binary formatter into the project as an optional capability that is only available if the ``prometheus_metrics_proto`` package is importable.
