### PR TITLE
Remove unused manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-recursive-include License *
-recursive-include tests *.py
-include requirements.txt
-include Makefile
-


### PR DESCRIPTION
This project uses wheels as distribution archives. The MANIFEST.in file is not used for binary wheel artefacts which means it is no longer needed in this project.