### PR TITLE
Fix upload rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ dist.test: dist
 
 
 # help: dist.upload                    - upload a wheel distribution package
-dist.upload: clean
+dist.upload:
 	@twine upload dist/aioprometheus-*-py3-none-any.whl
 
 


### PR DESCRIPTION
The ``dist.upload`` Makefile rule is broken. It calls clean which deletes the distribution, then it tries to upload a non-existant file.