### PR TITLE
Add Default for Accept: Header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Byte-compiled / optimized / DLL files
+ga# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
@@ -93,3 +93,6 @@ ENV/
 
 # vscode
 .vscode/
+
+# sublimttext
+/*.sublime-*

--- a/src/aioprometheus/service.py
+++ b/src/aioprometheus/service.py
@@ -211,7 +211,7 @@ class Service(object):
                 request: aiohttp.web.Request) -> Set[str]:
         ''' Return a sequence of accepts items in the request headers '''
         accepts = set()  # type: Set[str]
-        accept_headers = request.headers.getall(ACCEPT)
+        accept_headers = request.headers.getall(ACCEPT, [])
         logger.debug('accept: {}'.format(accept_headers))
         for accept_items in accept_headers:
             if ';' in accept_items:


### PR DESCRIPTION
At present aioprometheus blows up if it receives a request without an `Accept:` header set.  Witness:

```
$ curl -v --header "Accept:" http://my.prom.metrics:29137/metrics
...
< HTTP/1.1 500 Internal Server Error
< Date: Tue, 24 Apr 2018 16:17:29 GMT
< Content-Type: text/html; charset=utf-8
< Content-Length: 141
< Connection: keep-alive
< Server: Python/3.6 aiohttp/3.1.2
<
* Connection #0 to host my.prom.metrics left intact
<html><head><title>500 Internal Server Error</title></head><body><h1>500 Internal Server Error</h1>Server got itself in trouble</body></html>
```

It happens because the call to `request.headers.getall()` is made without a default to return if the `Accept:` header is missing.  Not a problem if you're Prometheus, but it is if you happen to be using this as an AWS ALB health check for your service.

I've added a default, `[]`, which allows `negotiate()` to do its thing and fall back to text mode.  I've tested it with a local deploy of the new code but `make venv` is [broken](https://github.com/Nekmo/amazon-dash/issues/44) by a known problem with `pip==10.0.1`.