### PR TITLE
Fixes for pip 10 and update tests to improve handling when no ACCEPT header is defined

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 import os
 import re
 
-from pip.req import parse_requirements
-from pip.download import PipSession
 from setuptools import setup, find_packages
 
 
@@ -23,6 +21,11 @@ with open(init_file, 'r') as f:
 
 with open('README.rst', 'r') as f:
     readme = f.read()
+
+def parse_requirements(filename):
+    ''' Load requirements from a pip requirements file '''
+    lineiter = (line.strip() for line in open(filename))
+    return [line for line in lineiter if line and not line.startswith("#")]
 
 with open('requirements.txt', 'r') as f:
     requirements = [line for line in f.read().split('\n') if len(line.strip())]

--- a/src/aioprometheus/negotiator.py
+++ b/src/aioprometheus/negotiator.py
@@ -12,7 +12,7 @@ FormatterType = Callable[[bool], formats.IFormatter]
 
 
 ProtobufAccepts = set(formats.BINARY_CONTENT_TYPE.split('; '))
-TextAccepts = set(formats.BINARY_CONTENT_TYPE.split('; '))
+TextAccepts = set(formats.TEXT_CONTENT_TYPE.split('; '))
 
 
 def negotiate(accepts: Set[str]) -> FormatterType:

--- a/tests/test_negotiate.py
+++ b/tests/test_negotiate.py
@@ -48,3 +48,8 @@ class TestNegotiate(unittest.TestCase):
         for accept in headers:
             self.assertEqual(
                 TextFormatter, negotiate(set(accept.split(';'))))
+
+    def test_no_accept_header(self):
+        ''' check request with no accept header works '''
+        self.assertEqual(TextFormatter, negotiate(set()))
+        self.assertEqual(TextFormatter, negotiate(set(['', ])))


### PR DESCRIPTION
- Apply fix to accomodate latest pip that moves some internal functions that were being used in the ``setup.py`` to parse ``requirements.txt``.
- Update tests to improve handling when no ACCEPT header is specified and add some docstrings to tests.