### PR TITLE
Adopt the Black code style formatter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,7 @@ install:
   - pip install dist/aioprometheus-*.whl
 script:
   - make test
-  - pip install pycodestyle
-  - make style
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install black; make style; fi
+matrix:
+  allow_failures:
+    - python: pypy3

--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,17 @@
 # help: aioprometheus Makefile help
 # help:
 
-STYLE_EXCLUDE_LIST:=git status --porcelain --ignored | grep "!!" | grep ".py$$" | cut -d " " -f2 | tr "\n" ","
-STYLE_MAX_LINE_LENGTH:=160
-STYLE_CMD:=pycodestyle --exclude=.git,docs,$(shell $(STYLE_EXCLUDE_LIST)) --ignore=E309,E402,W504 --max-line-length=$(STYLE_MAX_LINE_LENGTH) src/aioprometheus tests examples
 VENVS_DIR := $(HOME)/.venvs
 VENV_DIR := $(VENVS_DIR)/vap
 
 # help: help                           - display this makefile's help information
+.PHONY: help
 help:
 	@grep "^# help\:" Makefile | grep -v grep | sed 's/\# help\: //' | sed 's/\# help\://'
 
 
 # help: venv                           - create a virtual environment for development
+.PHONY: venv
 venv:
 	@test -d "$(VENVS_DIR)" || mkdir -p "$(VENVS_DIR)"
 	@rm -Rf "$(VENV_DIR)"
@@ -31,26 +30,31 @@ venv:
 
 
 # help: clean                          - clean all files using .gitignore rules
+.PHONY: clean
 clean:
 	@git clean -X -f -d
 
 
 # help: clean.scrub                    - clean all files, even untracked files
+.PHONY: clean.scrub
 clean.scrub:
 	git clean -x -f -d
 
 
 # help: test                           - run tests
+.PHONY: test
 test:
 	@python -m unittest discover -s tests
 
 
 # help: test.verbose                   - run tests [verbosely]
+.PHONY: test.verbose
 test.verbose:
 	@python -m unittest discover -s tests -v
 
 
 # help: coverage                       - perform test coverage checks
+.PHONY: coverage
 coverage:
 	@coverage run -m unittest discover -s tests
 	@# produce html coverage report on modules
@@ -59,25 +63,20 @@ coverage:
 	@cd docs/coverage; mv index.html coverage.html
 
 
-# help: style                          - perform pep8 check
+# help: style                          - perform code format compliance check
+.PHONY: style
 style:
-	@$(STYLE_CMD)
-
-
-# help: style.fix                      - perform check with autopep8 fixes
-style.fix:
-	@# If there are no files to fix then autopep8 typically returns an error
-	@# because it did not get passed any files to work on. Use xargs -r to
-	@# avoid this problem.
-	@$(STYLE_CMD) -q  | xargs -r autopep8 -i --max-line-length=$(STYLE_MAX_LINE_LENGTH)
+	@black src/aioprometheus tests examples
 
 
 # help: check_types                    - check type hint annotations
+.PHONY: check_types
 check_types:
 	@cd src; MYPYPATH=$VIRTUAL_ENV/lib/python*/site-packages mypy -p aioprometheus --ignore-missing-imports
 
 
 # help: docs                           - generate project documentation
+.PHONY: docs
 docs: coverage
 	@cd docs; rm -rf api/aioprometheus*.rst api/modules.rst _build/*
 	@cd docs; sphinx-apidoc -o ./api ../src/aioprometheus
@@ -86,21 +85,25 @@ docs: coverage
 
 
 # help: docs.serve                     - serve HTML documentation
+.PHONY: docs.serve
 docs.serve:
 	@cd docs; python -m http.server
 
 
 # help: dist                           - create a wheel distribution package
+.PHONY: dist
 dist: clean
 	@python setup.py bdist_wheel
 
 
 # help: dist.test                      - test a wheel distribution package
+.PHONY: dist.test
 dist.test: dist
 	@cd dist && ../tests/test_dist.bash ./aioprometheus-*-py3-none-any.whl
 
 
 # help: dist.upload                    - upload a wheel distribution package
+.PHONY: dist.upload
 dist.upload:
 	@twine upload dist/aioprometheus-*-py3-none-any.whl
 
@@ -108,6 +111,3 @@ dist.upload:
 # Keep these lines at the end of the file to retain nice help
 # output formatting.
 # help:
-
-.PHONY: \
-	check_types clean clean.scrub coverage docs dist dist.test dist.upload help style style.fix test test.verbose

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -100,6 +100,18 @@ package too.
     $ python -m unittest test_negotiate
 
 
+Code Style
+----------
+
+Adopting a consistent code style assists with maintenance. This project uses
+the Black code style formatter. A Makefile convenience rule to enforce code
+style compliance is available.
+
+.. code-block:: console
+
+    (venv) $ make style
+
+
 Type Annotations
 ----------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,9 @@
 .. image:: https://img.shields.io/pypi/v/aioprometheus.svg
     :target: https://pypi.python.org/pypi/aioprometheus
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+  :target: https://github.com/ambv/black
+
 aioprometheus
 =============
 

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -171,7 +171,7 @@ Simple Example
 The example below shows a single Counter metric collector being created
 and exposed via a HTTP endpoint.
 
-.. literalinclude:: ../examples/simple-example.py
+.. literalinclude:: ../../examples/simple-example.py
     :language: python3
 
 In this simple example the counter metric is tracking the number of

--- a/examples/app-example.py
+++ b/examples/app-example.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-'''
+"""
 This more complicated example implements an application that exposes
 application metrics obtained from the psutil package.
 
 This example requires the ``psutil`` package which can be installed
 using ``pip install psutil``.
-'''
+"""
 
 import asyncio
 import logging
@@ -14,28 +14,23 @@ import random
 import socket
 import uuid
 
-from aioprometheus import (
-    Counter,
-    Gauge,
-    Histogram,
-    Service,
-    Summary,
-    formats,
-)
+from aioprometheus import Counter, Gauge, Histogram, Service, Summary, formats
 
 from asyncio.base_events import BaseEventLoop
 
 
 class ExampleApp(object):
-    '''
+    """
     An example application that demonstrates how ``aioprometheus`` can be
     used within a Python async application.
-    '''
+    """
 
-    def __init__(self,
-                 metrics_host='127.0.0.1',
-                 metrics_port: int = 0,
-                 loop: BaseEventLoop = None):
+    def __init__(
+        self,
+        metrics_host="127.0.0.1",
+        metrics_port: int = 0,
+        loop: BaseEventLoop = None,
+    ):
 
         self.metrics_host = metrics_host
         self.metrics_port = metrics_port
@@ -51,16 +46,16 @@ class ExampleApp(object):
 
         # Define some constant labels that need to be added to all metrics
         const_labels = {
-            'host': socket.gethostname(),
-            'app': f'{self.__class__.__name__}-{uuid.uuid4().hex}'}
+            "host": socket.gethostname(),
+            "app": f"{self.__class__.__name__}-{uuid.uuid4().hex}",
+        }
 
         # Create metrics collectors
 
         # Create a counter metric to track requests
         self.requests_metric = Counter(
-            "requests",
-            "Number of requests.",
-            const_labels=const_labels)
+            "requests", "Number of requests.", const_labels=const_labels
+        )
 
         # Collectors must be registered with the registry before they
         # get exposed.
@@ -68,35 +63,36 @@ class ExampleApp(object):
 
         # Create a gauge metrics to track memory usage.
         self.ram_metric = Gauge(
-            "memory_usage_bytes",
-            "Memory usage in bytes.",
-            const_labels=const_labels)
+            "memory_usage_bytes", "Memory usage in bytes.", const_labels=const_labels
+        )
         self.msvr.register(self.ram_metric)
 
         # Create a gauge metrics to track CPU.
         self.cpu_metric = Gauge(
-            "cpu_usage_percent",
-            "CPU usage percent.",
-            const_labels=const_labels)
+            "cpu_usage_percent", "CPU usage percent.", const_labels=const_labels
+        )
         self.msvr.register(self.cpu_metric)
 
         self.payload_metric = Summary(
             "request_payload_size_bytes",
             "Request payload size in bytes.",
             const_labels=const_labels,
-            invariants=[(0.50, 0.05), (0.99, 0.001)])
+            invariants=[(0.50, 0.05), (0.99, 0.001)],
+        )
         self.msvr.register(self.payload_metric)
 
         self.latency_metric = Histogram(
-            "request_latency_seconds", "Request latency in seconds",
+            "request_latency_seconds",
+            "Request latency in seconds",
             const_labels=const_labels,
-            buckets=[0.1, 0.5, 1.0, 5.0])
+            buckets=[0.1, 0.5, 1.0, 5.0],
+        )
         self.msvr.register(self.latency_metric)
 
     async def start(self):
-        ''' Start the application '''
+        """ Start the application """
         await self.msvr.start(addr=self.metrics_host, port=self.metrics_port)
-        logger.debug('Serving prometheus metrics on: %s', self.msvr.metrics_url)
+        logger.debug("Serving prometheus metrics on: %s", self.msvr.metrics_url)
 
         # Schedule a timer to update internal metrics. In a realistic
         # application metrics would be updated as needed. In this example
@@ -105,42 +101,42 @@ class ExampleApp(object):
         self.timer = self.loop.call_later(1.0, self.on_timer_expiry)
 
     async def stop(self):
-        ''' Stop the application '''
+        """ Stop the application """
         await self.msvr.stop()
         if self.timer:
             self.timer.cancel()
         self.timer = None
 
     def on_timer_expiry(self):
-        ''' Update application to simulate work '''
+        """ Update application to simulate work """
 
         # Update memory metrics
-        self.ram_metric.set({'type': "virtual", }, psutil.virtual_memory().used)
-        self.ram_metric.set({'type': "swap"}, psutil.swap_memory().used)
+        self.ram_metric.set({"type": "virtual"}, psutil.virtual_memory().used)
+        self.ram_metric.set({"type": "swap"}, psutil.swap_memory().used)
 
         # Update cpu metrics
         for c, p in enumerate(psutil.cpu_percent(interval=1, percpu=True)):
-            self.cpu_metric.set({'core': c}, p)
+            self.cpu_metric.set({"core": c}, p)
 
         # Incrementing a requests counter to emulate webserver app
-        self.requests_metric.inc({'path': "/"})
+        self.requests_metric.inc({"path": "/"})
 
         # Monitor request payload data to emulate webserver app
-        self.payload_metric.add({'path': "/data"}, random.random() * 2**10)
+        self.payload_metric.add({"path": "/data"}, random.random() * 2 ** 10)
 
         # Monitor request latency to emulate webserver app
-        self.latency_metric.add({'path': "/data"}, random.random() * 5)
+        self.latency_metric.add({"path": "/data"}, random.random() * 5)
 
         # re-schedule another metrics update
         self.timer = self.loop.call_later(1.0, self.on_timer_expiry)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     logging.basicConfig(level=logging.DEBUG)
     # Silence asyncio and aiohttp loggers
-    logging.getLogger('asyncio').setLevel(logging.ERROR)
-    logging.getLogger('aiohttp').setLevel(logging.ERROR)
+    logging.getLogger("asyncio").setLevel(logging.ERROR)
+    logging.getLogger("aiohttp").setLevel(logging.ERROR)
     logger = logging.getLogger(__name__)
 
     loop = asyncio.get_event_loop()

--- a/examples/decorator_count_exceptions.py
+++ b/examples/decorator_count_exceptions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-'''
+"""
 
 .. code-block:: python
 
@@ -16,7 +16,7 @@ The example script can be tested using ``curl``.
 
 You may need to Ctrl+C twice to exit the example script.
 
-'''
+"""
 
 import asyncio
 import random
@@ -25,16 +25,15 @@ from aioprometheus import Service, Counter, count_exceptions
 
 
 # Create a metric to track requests currently in progress.
-REQUESTS = Counter(
-    'request_handler_exceptions', 'Number of exceptions in requests')
+REQUESTS = Counter("request_handler_exceptions", "Number of exceptions in requests")
 
 
 # Decorate function with metric.
-@count_exceptions(REQUESTS, {'route': '/'})
+@count_exceptions(REQUESTS, {"route": "/"})
 async def handle_request(duration):
-    ''' A dummy function that occasionally raises an exception '''
+    """ A dummy function that occasionally raises an exception """
     if duration < 0.3:
-        raise Exception('Ooops')
+        raise Exception("Ooops")
     await asyncio.sleep(duration)
 
 
@@ -49,7 +48,7 @@ async def handle_requests():
             pass  # keep handling
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
 

--- a/examples/decorator_inprogress.py
+++ b/examples/decorator_inprogress.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-'''
+"""
 
 .. code-block:: python
 
@@ -14,7 +14,7 @@ The example script can be tested using ``curl``.
     # TYPE request_in_progress gauge
     request_in_progress{route="/"} 1
 
-'''
+"""
 
 import asyncio
 import random
@@ -23,14 +23,13 @@ from aioprometheus import Service, Gauge, inprogress
 
 
 # Create a metric to track requests currently in progress.
-REQUESTS = Gauge(
-    'request_in_progress', 'Number of requests in progress')
+REQUESTS = Gauge("request_in_progress", "Number of requests in progress")
 
 
 # Decorate function with metric.
-@inprogress(REQUESTS, {'route': '/'})
+@inprogress(REQUESTS, {"route": "/"})
 async def handle_request(duration):
-    ''' A dummy function that takes some time '''
+    """ A dummy function that takes some time """
     await asyncio.sleep(duration)
 
 
@@ -42,7 +41,7 @@ async def handle_requests():
         await handle_request(random.random())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
 

--- a/examples/decorator_timer.py
+++ b/examples/decorator_timer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-'''
+"""
 Usage:
 
 .. code-block:: python
@@ -19,7 +19,7 @@ The example script can be tested using ``curl``.
     request_processing_seconds{quantile="0.9"} 0.5016570091247559
     request_processing_seconds{quantile="0.99"} 0.6077709197998047
 
-'''
+"""
 
 import asyncio
 import random
@@ -28,14 +28,13 @@ from aioprometheus import Service, Summary, timer
 
 
 # Create a metric to track time spent and requests made.
-REQUEST_TIME = Summary(
-    'request_processing_seconds', 'Time spent processing request')
+REQUEST_TIME = Summary("request_processing_seconds", "Time spent processing request")
 
 
 # Decorate function with metric.
 @timer(REQUEST_TIME)
 async def handle_request(duration):
-    ''' A dummy function that takes some time '''
+    """ A dummy function that takes some time """
     await asyncio.sleep(duration)
 
 
@@ -47,7 +46,7 @@ async def handle_requests():
         await handle_request(random.random())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
 

--- a/examples/metrics-fetcher.py
+++ b/examples/metrics-fetcher.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-'''
+"""
 This script implements a fetching function that emulates Prometheus server
 scraping a metrics service endpoint. The fetching function can randomly
 requests metrics in text or binary formats or you can specify a format to
@@ -10,7 +10,7 @@ Usage:
 
     $ python metrics-fetcher.py --url http://0.0.0.0:50123/metrics --format=text --interval=2.0
 
-'''
+"""
 
 import aiohttp
 import aioprometheus
@@ -23,23 +23,22 @@ from aiohttp.hdrs import ACCEPT, CONTENT_TYPE
 from asyncio.base_events import BaseEventLoop
 
 
-TEXT = 'text'
-BINARY = 'binary'
+TEXT = "text"
+BINARY = "binary"
 header_kinds = {
     TEXT: aioprometheus.formats.TEXT_CONTENT_TYPE,  # 'text/plain',
     BINARY: aioprometheus.formats.BINARY_CONTENT_TYPE,
 }
 
 
-async def fetch_metrics(url: str,
-                        fmt: str = None,
-                        interval: float = 1.0,
-                        loop: BaseEventLoop = None):
-    ''' Fetch metrics from the service endpoint using different formats.
+async def fetch_metrics(
+    url: str, fmt: str = None, interval: float = 1.0, loop: BaseEventLoop = None
+):
+    """ Fetch metrics from the service endpoint using different formats.
 
     This coroutine runs 'n' times, with a brief interval in between, before
     exiting.
-    '''
+    """
     if fmt is None:
         # Randomly choose a format to request metrics in.
         choice = random.choice((TEXT, BINARY))
@@ -47,15 +46,15 @@ async def fetch_metrics(url: str,
         assert fmt in header_kinds
         choice = fmt
 
-    print(f'fetching metrics in {choice} format')
+    print(f"fetching metrics in {choice} format")
     async with aiohttp.ClientSession() as session:
         async with session.get(url, headers={ACCEPT: header_kinds[choice]}) as resp:
             assert resp.status == 200
             content = await resp.read()
             content_type = resp.headers.get(CONTENT_TYPE)
-            print('Content-Type: {}'.format(content_type))
-            print('size: {}'.format(len(content)))
-            if choice == 'text':
+            print("Content-Type: {}".format(content_type))
+            print("size: {}".format(len(content)))
+            if choice == "text":
                 print(content.decode())
             else:
                 print(content)
@@ -70,38 +69,40 @@ def fetch_task(url, fmt, interval, loop):
     asyncio.ensure_future(fetch_metrics(url, fmt, interval, loop))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
-    ARGS = argparse.ArgumentParser(description='Metrics Fetcher')
+    ARGS = argparse.ArgumentParser(description="Metrics Fetcher")
+    ARGS.add_argument("--url", type=str, default=None, help="The metrics URL")
     ARGS.add_argument(
-        '--url', type=str,
+        "--format",
+        type=str,
         default=None,
-        help='The metrics URL')
+        help="Metrics response format (i.e. 'text' or 'binary'",
+    )
     ARGS.add_argument(
-        '--format', type=str,
-        default=None,
-        help="Metrics response format (i.e. 'text' or 'binary'")
-    ARGS.add_argument(
-        '--interval', type=float,
+        "--interval",
+        type=float,
         default=1.0,
-        help='The number of seconds between metrics requests')
+        help="The number of seconds between metrics requests",
+    )
     ARGS.add_argument(
-        '--debug', default=False, action="store_true",
-        help='Show debug output')
+        "--debug", default=False, action="store_true", help="Show debug output"
+    )
 
     args = ARGS.parse_args()
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
         # Silence asyncio and aiohttp loggers
-        logging.getLogger('asyncio').setLevel(logging.ERROR)
-        logging.getLogger('aiohttp').setLevel(logging.ERROR)
+        logging.getLogger("asyncio").setLevel(logging.ERROR)
+        logging.getLogger("aiohttp").setLevel(logging.ERROR)
 
     loop = asyncio.get_event_loop()
 
     # create a task to fetch metrics at a periodic interval
     loop.call_later(
-        args.interval, fetch_task, args.url, args.format, args.interval, loop)
+        args.interval, fetch_task, args.url, args.format, args.interval, loop
+    )
 
     try:
         loop.run_forever()

--- a/examples/simple-example.py
+++ b/examples/simple-example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-'''
+"""
 This example demonstrates how a single Counter metric collector can be created
 and exposed via a HTTP endpoint.
 
@@ -10,33 +10,32 @@ and exposed via a HTTP endpoint.
 
 In another terminal fetch the metrics using the ``curl`` command line tool
 to verify they can be retrieved by Prometheus server.
-'''
+"""
 import asyncio
 import socket
 from aioprometheus import Counter, Service
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
 
     svr = Service()
 
     events_counter = Counter(
-        "events",
-        "Number of events.",
-        const_labels={'host': socket.gethostname()})
+        "events", "Number of events.", const_labels={"host": socket.gethostname()}
+    )
 
     svr.register(events_counter)
 
     loop.run_until_complete(svr.start(addr="127.0.0.1"))
-    print(f'Serving prometheus metrics on: {svr.metrics_url}')
+    print(f"Serving prometheus metrics on: {svr.metrics_url}")
 
     async def updater(m: Counter):
         # Periodically update the metric to simulate some progress
         # happening in a real application.
         while True:
-            m.inc({'kind': 'timer_expiry'})
+            m.inc({"kind": "timer_expiry"})
             await asyncio.sleep(1.0)
 
     try:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
-autopep8
-pycodestyle
+black
 sphinx
 coverage
 mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp >= 3.2.1
 asynctest
 prometheus-metrics-proto >= 18.1.1
 quantile-python >= 1.1

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,15 @@ with open('README.rst', 'r') as f:
 
 def parse_requirements(filename):
     ''' Load requirements from a pip requirements file '''
-    lineiter = (line.strip() for line in open(filename))
-    return [line for line in lineiter if line and not line.startswith("#")]
+    with open(filename, 'r') as fd:
+        lines = []
+        for line in fd:
+            line.strip()
+            if line and not line.startswith("#"):
+                lines.append(line)
+    return lines
 
-with open('requirements.txt', 'r') as f:
-    requirements = [line for line in f.read().split('\n') if len(line.strip())]
+requirements = parse_requirements('requirements.txt')
 
 
 if __name__ == "__main__":

--- a/src/aioprometheus/__init__.py
+++ b/src/aioprometheus/__init__.py
@@ -1,6 +1,5 @@
 
-from .collectors import (
-    Collector, Counter, Gauge, Summary, Histogram)
+from .collectors import Collector, Counter, Gauge, Summary, Histogram
 from .decorators import count_exceptions, inprogress, timer
 from . import formats
 from . import pusher

--- a/src/aioprometheus/collectors.py
+++ b/src/aioprometheus/collectors.py
@@ -15,9 +15,9 @@ from typing import cast, Any, Dict, List, Sequence, Tuple, Union
 decoder = json.JSONDecoder(object_pairs_hook=collections.OrderedDict)  # type: ignore
 
 
-METRIC_NAME_RE = re.compile(r'^[a-zA-Z_:][a-zA-Z0-9_:]*$')
-RESTRICTED_LABELS_NAMES = ('job',)
-RESTRICTED_LABELS_PREFIXES = ('__',)
+METRIC_NAME_RE = re.compile(r"^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+RESTRICTED_LABELS_NAMES = ("job",)
+RESTRICTED_LABELS_PREFIXES = ("__",)
 
 POS_INF = float("inf")
 NEG_INF = float("-inf")
@@ -26,7 +26,7 @@ NEG_INF = float("-inf")
 LabelsType = Dict[str, str]
 NumericValueType = Union[int, float, histogram.Histogram, quantile.Estimator]
 ValueType = Union[str, NumericValueType]
-CollectorsType = Union['Counter', 'Gauge', 'Histogram', 'Summary']
+CollectorsType = Union["Counter", "Gauge", "Histogram", "Summary"]
 
 
 class MetricsTypes(enum.Enum):
@@ -38,7 +38,7 @@ class MetricsTypes(enum.Enum):
 
 
 class Collector(object):
-    ''' Base class for all collectors.
+    """ Base class for all collectors.
 
     **Metric names and labels**
 
@@ -81,16 +81,13 @@ class Collector(object):
 
         api_http_requests_total{method="POST", handler="/messages"}
 
-    '''
+    """
 
     kind = MetricsTypes.untyped
 
-    def __init__(self,
-                 name: str,
-                 doc: str,
-                 const_labels: LabelsType = None) -> None:
+    def __init__(self, name: str, doc: str, const_labels: LabelsType = None) -> None:
         if not METRIC_NAME_RE.match(name):
-            raise ValueError('Invalid metric name: {}'.format(name))
+            raise ValueError("Invalid metric name: {}".format(name))
         self.name = name
         self.doc = doc
         self.const_labels = const_labels
@@ -102,39 +99,39 @@ class Collector(object):
         self.values = MetricDict()
 
     def set_value(self, labels: LabelsType, value: NumericValueType) -> None:
-        '''  Sets a value in the container '''
+        """  Sets a value in the container """
         if labels:
             self._label_names_correct(labels)
         self.values[labels] = value
 
     def get_value(self, labels: LabelsType) -> NumericValueType:
-        '''  Gets a value in the container.
+        """  Gets a value in the container.
 
         :raises: KeyError if an item with matching labels is not present.
-        '''
+        """
         return self.values[labels]
 
     def get(self, labels: LabelsType) -> NumericValueType:
-        ''' Gets a value in the container.
+        """ Gets a value in the container.
 
         Handy alias for `get_value`.
 
         :raises: KeyError if an item with matching labels is not present.
-        '''
+        """
         return self.get_value(labels)
 
     def _label_names_correct(self, labels: LabelsType) -> bool:
-        ''' Check validity of label names.
+        """ Check validity of label names.
 
         :raises: ValueError if labels are invalid
-        '''
+        """
         for k, v in labels.items():
             # Check reserved labels
             if k in RESTRICTED_LABELS_NAMES:
                 raise ValueError("Invalid label name: {}".format(k))
 
             if self.kind == MetricsTypes.histogram:
-                if k in ('le', ):
+                if k in ("le",):
                     raise ValueError("Invalid label name: {}".format(k))
 
             # Check prefixes
@@ -144,11 +141,11 @@ class Collector(object):
         return True
 
     def get_all(self) -> List[Tuple[LabelsType, NumericValueType]]:
-        '''
+        """
         Returns a list populated with 2-tuples. The first element is
         a dict of labels and the second element is the value of the metric
         itself.
-        '''
+        """
         items = self.values.items()
 
         result = []
@@ -164,15 +161,16 @@ class Collector(object):
 
     def __eq__(self, other) -> bool:
         return (
-            isinstance(other, self.__class__) and
-            self.name == other.name and  # type: ignore
-            self.doc == other.doc and  # type: ignore
-            type(self) == type(other) and  # type: ignore
-            self.values == other.values)  # type: ignore
+            isinstance(other, self.__class__)
+            and self.name == other.name
+            and self.doc == other.doc  # type: ignore
+            and type(self) == type(other)  # type: ignore
+            and self.values == other.values  # type: ignore
+        )  # type: ignore
 
 
 class Counter(Collector):
-    '''
+    """
     A counter is a cumulative metric that represents a single numerical value
     that only ever goes up. A counter is typically used to count requests
     served, tasks completed, errors occurred, etc. Counters should not be used
@@ -183,35 +181,31 @@ class Counter(Collector):
     - Number of requests processed
     - Number of items that were inserted into a queue
     - Total amount of data that a system has processed
-    '''
+    """
 
     kind = MetricsTypes.counter
 
     def get(self, labels: LabelsType) -> NumericValueType:
-        ''' Get the Counter value matching an arbitrary group of labels.
+        """ Get the Counter value matching an arbitrary group of labels.
 
         :raises: KeyError if an item with matching labels is not present.
-        '''
+        """
         return self.get_value(labels)
 
-    def set(self,
-            labels: LabelsType,
-            value: NumericValueType) -> None:
-        ''' Set the counter to an arbitrary value. '''
+    def set(self, labels: LabelsType, value: NumericValueType) -> None:
+        """ Set the counter to an arbitrary value. """
         self.set_value(labels, value)
 
     def inc(self, labels: LabelsType) -> None:
-        ''' Increments the counter by 1.'''
+        """ Increments the counter by 1."""
         self.add(labels, 1)
 
-    def add(self,
-            labels: LabelsType,
-            value: NumericValueType) -> None:
-        ''' Add the given value to the counter.
+    def add(self, labels: LabelsType, value: NumericValueType) -> None:
+        """ Add the given value to the counter.
 
         :raises: ValueError if the value is negative. Counters can only
           increase.
-        '''
+        """
         value = cast(Union[float, int], value)  # typing check, no runtime behaviour.
         if value < 0:
             raise ValueError("Counters can't decrease")
@@ -221,12 +215,14 @@ class Counter(Collector):
         except KeyError:
             current = 0
 
-        current = cast(Union[float, int], current)  # typing check, no runtime behaviour.
+        current = cast(
+            Union[float, int], current
+        )  # typing check, no runtime behaviour.
         self.set_value(labels, current + value)
 
 
 class Gauge(Collector):
-    '''
+    """
     A gauge is a metric that represents a single numerical value that can
     arbitrarily go up and down.
 
@@ -238,61 +234,57 @@ class Gauge(Collector):
     - Temperature
 
     Gauges can go both up and down.
-    '''
+    """
 
     kind = MetricsTypes.gauge
 
-    def set(self,
-            labels: LabelsType,
-            value: NumericValueType) -> None:
-        ''' Set the gauge to an arbitrary value.'''
+    def set(self, labels: LabelsType, value: NumericValueType) -> None:
+        """ Set the gauge to an arbitrary value."""
         self.set_value(labels, value)
 
     def get(self, labels: LabelsType) -> NumericValueType:
-        ''' Get the gauge value matching an arbitrary group of labels.
+        """ Get the gauge value matching an arbitrary group of labels.
 
         :raises: KeyError if an item with matching labels is not present.
-        '''
+        """
         return self.get_value(labels)
 
     def inc(self, labels: LabelsType) -> None:
-        ''' Increments the gauge by 1.'''
+        """ Increments the gauge by 1."""
         self.add(labels, 1)
 
     def dec(self, labels: LabelsType) -> None:
-        ''' Decrement the gauge by 1.'''
+        """ Decrement the gauge by 1."""
         self.add(labels, -1)
 
-    def add(self,
-            labels: LabelsType,
-            value: NumericValueType) -> None:
-        ''' Add the given value to the Gauge.
+    def add(self, labels: LabelsType, value: NumericValueType) -> None:
+        """ Add the given value to the Gauge.
 
         The value can be negative, resulting in a decrease of the gauge.
-        '''
+        """
         value = cast(Union[float, int], value)  # typing check, no runtime behaviour.
 
         try:
             current = self.get_value(labels)
         except KeyError:
             current = 0
-        current = cast(Union[float, int], current)  # typing check, no runtime behaviour.
+        current = cast(
+            Union[float, int], current
+        )  # typing check, no runtime behaviour.
 
         self.set_value(labels, current + value)
 
-    def sub(self,
-            labels: LabelsType,
-            value: NumericValueType) -> None:
-        ''' Subtract the given value from the Gauge.
+    def sub(self, labels: LabelsType, value: NumericValueType) -> None:
+        """ Subtract the given value from the Gauge.
 
         The value can be negative, resulting in an increase of the gauge.
-        '''
+        """
         value = cast(Union[float, int], value)  # typing check, no runtime behaviour.
         self.add(labels, -value)
 
 
 class Summary(Collector):
-    '''
+    """
     A Summary metric captures individual observations from an event or sample
     stream and summarizes them in a manner similar to traditional summary
     statistics:
@@ -304,7 +296,7 @@ class Summary(Collector):
     Example use cases for Summaries:
     - Response latency
     - Request size
-    '''
+    """
 
     kind = MetricsTypes.summary
 
@@ -313,18 +305,18 @@ class Summary(Collector):
     SUM_KEY = "sum"
     COUNT_KEY = "count"
 
-    def __init__(self,
-                 name: str,
-                 doc: str,
-                 const_labels: LabelsType = None,
-                 invariants: Sequence[Tuple[float, float]] = DEFAULT_INVARIANTS) -> None:
+    def __init__(
+        self,
+        name: str,
+        doc: str,
+        const_labels: LabelsType = None,
+        invariants: Sequence[Tuple[float, float]] = DEFAULT_INVARIANTS,
+    ) -> None:
         super().__init__(name, doc, const_labels=const_labels)
         self.invariants = invariants
 
-    def add(self,
-            labels: LabelsType,
-            value: NumericValueType) -> None:
-        ''' Add a single observation to the summary '''
+    def add(self, labels: LabelsType, value: NumericValueType) -> None:
+        """ Add a single observation to the summary """
 
         value = cast(Union[float, int], value)  # typing check, no runtime behaviour.
         if type(value) not in (float, int):
@@ -343,14 +335,13 @@ class Summary(Collector):
     # A summary MUST have the ``observe`` methods
     observe = add
 
-    def get(self,
-            labels: LabelsType) -> Dict[Union[float, str], NumericValueType]:
-        '''
+    def get(self, labels: LabelsType) -> Dict[Union[float, str], NumericValueType]:
+        """
         Get a dict of values, containing the sum, count and quantiles,
         matching an arbitrary group of labels.
 
         :raises: KeyError if an item with matching labels is not present.
-        '''
+        """
         return_data = {}  # type: Dict[Union[float, str], NumericValueType]
 
         e = self.get_value(labels)
@@ -369,34 +360,46 @@ class Summary(Collector):
 
 
 class Histogram(Collector):
-    '''
+    """
     A Histogram metric tracks the size and number of events in buckets.
 
     Example use cases:
     - Response latency
     - Request size
-    '''
+    """
 
     kind = MetricsTypes.histogram
 
     REPR_STR = "histogram"
-    DEFAULT_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
-                       0.5, 1.0, 2.5, 5.0, 10.0, POS_INF)
+    DEFAULT_BUCKETS = (
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        10.0,
+        POS_INF,
+    )
     SUM_KEY = "sum"
     COUNT_KEY = "count"
 
-    def __init__(self,
-                 name: str,
-                 doc: str,
-                 const_labels: LabelsType = None,
-                 buckets: Sequence[float] = DEFAULT_BUCKETS) -> None:
+    def __init__(
+        self,
+        name: str,
+        doc: str,
+        const_labels: LabelsType = None,
+        buckets: Sequence[float] = DEFAULT_BUCKETS,
+    ) -> None:
         super().__init__(name, doc, const_labels=const_labels)
         self.upper_bounds = buckets
 
-    def add(self,
-            labels: LabelsType,
-            value: NumericValueType) -> None:
-        ''' Add a single observation to the histogram '''
+    def add(self, labels: LabelsType, value: NumericValueType) -> None:
+        """ Add a single observation to the histogram """
 
         value = cast(Union[float, int], value)  # typing check, no runtime behaviour.
         if type(value) not in (float, int):
@@ -416,14 +419,13 @@ class Histogram(Collector):
     # A histogram MUST have the ``observe`` methods
     observe = add
 
-    def get(self,
-            labels: LabelsType) -> Dict[Union[float, str], NumericValueType]:
-        '''
+    def get(self, labels: LabelsType) -> Dict[Union[float, str], NumericValueType]:
+        """
         Get a dict of values, containing the sum, count and buckets,
         matching an arbitrary group of labels.
 
         :raises: KeyError if an item with matching labels is not present.
-        '''
+        """
         return_data = {}  # type: Dict[Union[float, str], NumericValueType]
 
         h = self.get_value(labels)

--- a/src/aioprometheus/decorators.py
+++ b/src/aioprometheus/decorators.py
@@ -1,6 +1,6 @@
-'''
+"""
 This module provides some convenience decorators for metrics
-'''
+"""
 
 import asyncio
 import time
@@ -10,9 +10,8 @@ from functools import wraps
 from typing import Any, Callable, Dict
 
 
-def timer(metric: Summary,
-          labels: Dict[str, str] = None) -> Callable[..., Any]:
-    '''
+def timer(metric: Summary, labels: Dict[str, str] = None) -> Callable[..., Any]:
+    """
     This decorator provides a convenient way to time a callable.
 
     This decorator function wraps a function with code to calculate how long
@@ -26,21 +25,22 @@ def timer(metric: Summary,
     :param labels: a dict of extra labels to associate with the metric.
 
     :return: a coroutine function that wraps the decortated function
-    '''
+    """
     if not isinstance(metric, Summary):
         raise Exception(
-            'timer decorator expects a Summary metric but got: {}'.format(
-                metric))
+            "timer decorator expects a Summary metric but got: {}".format(metric)
+        )
 
     def measure(func):
-        '''
+        """
         This function wraps a decorated callable with timing and metric
         updating logic.
 
         :param func: the callable to be timed.
 
         :returns: the return value from the decorated callable.
-        '''
+        """
+
         @wraps(func)
         async def func_wrapper(*args, **kwds):
             start_time = time.monotonic()
@@ -55,9 +55,8 @@ def timer(metric: Summary,
     return measure
 
 
-def inprogress(metric: Gauge,
-               labels: Dict[str, str] = None) -> Callable[..., Any]:
-    '''
+def inprogress(metric: Gauge, labels: Dict[str, str] = None) -> Callable[..., Any]:
+    """
     This decorator provides a convenient way to track in-progress requests
     (or other things) in a callable.
 
@@ -73,21 +72,22 @@ def inprogress(metric: Gauge,
     :param labels: a dict of extra labels to associate with the metric.
 
     :return: a coroutine function that wraps the decortated function
-    '''
+    """
     if not isinstance(metric, Gauge):
         raise Exception(
-            'inprogess decorator expects a Gauge metric but got: {}'.format(
-                metric))
+            "inprogess decorator expects a Gauge metric but got: {}".format(metric)
+        )
 
     def track(func):
-        '''
+        """
         This function wraps a decorated callable with metric incremeting
         and decrementing logic.
 
         :param func: the callable to be tracked.
 
         :returns: the return value from the decorated callable.
-        '''
+        """
+
         @wraps(func)
         async def func_wrapper(*args, **kwds):
             metric.inc(labels)
@@ -102,9 +102,10 @@ def inprogress(metric: Gauge,
     return track
 
 
-def count_exceptions(metric: Counter,
-                     labels: Dict[str, str] = None) -> Callable[..., Any]:
-    '''
+def count_exceptions(
+    metric: Counter, labels: Dict[str, str] = None
+) -> Callable[..., Any]:
+    """
     This decorator provides a convenient way to track count exceptions
     generated in a callable.
 
@@ -117,21 +118,24 @@ def count_exceptions(metric: Counter,
     :param labels: a dict of extra labels to associate with the metric.
 
     :return: a coroutine function that wraps the decortated function
-    '''
+    """
     if not isinstance(metric, Counter):
         raise Exception(
-            'count_exceptions decorator expects a Counter metric but got: {}'.format(
-                metric))
+            "count_exceptions decorator expects a Counter metric but got: {}".format(
+                metric
+            )
+        )
 
     def track(func):
-        '''
+        """
         This function wraps a decorated callable with metric incremeting
         logic.
 
         :param func: the callable to be tracked.
 
         :returns: the return value from the decorated callable.
-        '''
+        """
+
         @wraps(func)
         async def func_wrapper(*args, **kwds):
             try:

--- a/src/aioprometheus/formats/base.py
+++ b/src/aioprometheus/formats/base.py
@@ -10,37 +10,37 @@ LabelsType = Dict[str, str]
 
 
 class IFormatter(abc.ABC):
-    ''' Formatter interface '''
+    """ Formatter interface """
 
     @abc.abstractmethod
     def get_headers(self):
-        ''' Returns a dict of headers for this response format '''
+        """ Returns a dict of headers for this response format """
 
     @abc.abstractmethod
     def _format_counter(self, counter, name, const_labels):
-        '''
+        """
         Returns a representation of a counter value in the implemented
         format.
         :param counter: a 2-tuple containing labels and the counter value.
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
 
     @abc.abstractmethod
     def _format_gauge(self, gauge, name, const_labels):
-        '''
+        """
         Returns a representation of a gauge value in the implemented
         format.
         :param gauge: a 2-tuple containing labels and the gauge value.
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
 
     @abc.abstractmethod
     def _format_summary(self, summary, name, const_labels):
-        '''
+        """
         Returns a representation of a summary value in the implemented
         format.
 
@@ -50,11 +50,11 @@ class IFormatter(abc.ABC):
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
 
     @abc.abstractmethod
     def _format_histogram(self, histogram, name, const_labels):
-        '''
+        """
         Returns a representation of a histogram value in the implemented
         format.
 
@@ -64,21 +64,20 @@ class IFormatter(abc.ABC):
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
 
     @abc.abstractmethod
     def marshall(self, registry) -> bytes:
-        ''' Marshalls a registry (containing many collectors) into a
+        """ Marshalls a registry (containing many collectors) into a
         specific format.
 
         :returns: bytes
-        '''
+        """
 
-    def _unify_labels(self,
-                      labels: LabelsType,
-                      const_labels: LabelsType,
-                      ordered: bool = False) -> LabelsType:
-        '''
+    def _unify_labels(
+        self, labels: LabelsType, const_labels: LabelsType, ordered: bool = False
+    ) -> LabelsType:
+        """
         Return a dict of all labels for a metric. This combines the explicit
         labels and any constant labels. If ordered is True then the labels
         are sorted by key.
@@ -86,7 +85,7 @@ class IFormatter(abc.ABC):
         :param labels: a dict of labels for a metric.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
         if const_labels:
             result = const_labels.copy()
             if labels:
@@ -97,15 +96,12 @@ class IFormatter(abc.ABC):
             result = labels
 
         if ordered and result:
-            result = collections.OrderedDict(
-                sorted(result.items(), key=lambda t: t[0]))
+            result = collections.OrderedDict(sorted(result.items(), key=lambda t: t[0]))
 
         return result
 
     def _get_timestamp(self) -> int:
-        '''
+        """
         Return a timestamp that can be used by a metric formatter.
-        '''
-        return int(
-            datetime.datetime.now(
-                tz=datetime.timezone.utc).timestamp() * 1000)
+        """
+        return int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp() * 1000)

--- a/src/aioprometheus/formats/binary.py
+++ b/src/aioprometheus/formats/binary.py
@@ -1,7 +1,7 @@
-'''
+"""
 This module implements a formatter that emits metrics in a binary (Google
 Protocol Buffers) format.
-'''
+"""
 
 import prometheus_metrics_proto as pmp
 
@@ -25,72 +25,75 @@ MetricTupleType = Tuple[LabelsType, MetricValueType]
 FormatterFuncType = Callable[[MetricTupleType, str, LabelsType], pmp.Metric]
 
 
-BINARY_CONTENT_TYPE = ('application/vnd.google.protobuf; '
-                       'proto=io.prometheus.client.MetricFamily; '
-                       'encoding=delimited')
+BINARY_CONTENT_TYPE = (
+    "application/vnd.google.protobuf; "
+    "proto=io.prometheus.client.MetricFamily; "
+    "encoding=delimited"
+)
 
 
 class BinaryFormatter(IFormatter):
-    ''' This formatter encodes into the Protocol Buffers binary format '''
+    """ This formatter encodes into the Protocol Buffers binary format """
 
     def __init__(self, timestamp: bool = False) -> None:
-        '''
+        """
         :param timestamp: a boolean flag that when True will add a timestamp
           to metric.
-        '''
+        """
         self.timestamp = timestamp
-        self._headers = {'Content-Type': BINARY_CONTENT_TYPE}
+        self._headers = {"Content-Type": BINARY_CONTENT_TYPE}
 
     def get_headers(self) -> Dict[str, str]:
         return self._headers
 
-    def _format_counter(self,
-                        counter: MetricTupleType,
-                        name: str,
-                        const_labels: LabelsType) -> pmp.Metric:
-        ''' Create a Counter metric instance.
+    def _format_counter(
+        self, counter: MetricTupleType, name: str, const_labels: LabelsType
+    ) -> pmp.Metric:
+        """ Create a Counter metric instance.
 
         :param counter: a 2-tuple containing labels and the counter value.
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
         counter_labels, counter_value = counter
 
         metric = pmp.utils.create_counter_metric(
-            counter_labels, counter_value,
+            counter_labels,
+            counter_value,
             timestamp=self.timestamp,
             const_labels=const_labels,
-            ordered=True)
+            ordered=True,
+        )
 
         return metric
 
-    def _format_gauge(self,
-                      gauge: MetricTupleType,
-                      name: str,
-                      const_labels: LabelsType) -> pmp.Metric:
-        ''' Create a Gauge metric instance.
+    def _format_gauge(
+        self, gauge: MetricTupleType, name: str, const_labels: LabelsType
+    ) -> pmp.Metric:
+        """ Create a Gauge metric instance.
 
         :param gauge: a 2-tuple containing labels and the gauge value.
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
         gauge_labels, gauge_value = gauge
 
         metric = pmp.utils.create_gauge_metric(
-            gauge_labels, gauge_value,
+            gauge_labels,
+            gauge_value,
             timestamp=self.timestamp,
             const_labels=const_labels,
-            ordered=True)
+            ordered=True,
+        )
 
         return metric
 
-    def _format_summary(self,
-                        summary: MetricTupleType,
-                        name: str,
-                        const_labels: LabelsType) -> pmp.Metric:
-        ''' Create a Summary metric instance.
+    def _format_summary(
+        self, summary: MetricTupleType, name: str, const_labels: LabelsType
+    ) -> pmp.Metric:
+        """ Create a Summary metric instance.
 
         :param summary: a 2-tuple containing labels and a dict representing
           the summary value. The dict contains keys for each quantile as
@@ -98,56 +101,58 @@ class BinaryFormatter(IFormatter):
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
 
         summary_labels, summary_value_dict = summary
         # typing check, no runtime behaviour.
         summary_value_dict = cast(SummaryDictType, summary_value_dict)
 
         metric = pmp.utils.create_summary_metric(
-            summary_labels, summary_value_dict,
-            samples_count=summary_value_dict['count'],
-            samples_sum=summary_value_dict['sum'],
+            summary_labels,
+            summary_value_dict,
+            samples_count=summary_value_dict["count"],
+            samples_sum=summary_value_dict["sum"],
             timestamp=self.timestamp,
             const_labels=const_labels,
-            ordered=True)
+            ordered=True,
+        )
 
         return metric
 
-    def _format_histogram(self,
-                          histogram: MetricTupleType,
-                          name: str,
-                          const_labels: LabelsType) -> pmp.Metric:
-        '''
+    def _format_histogram(
+        self, histogram: MetricTupleType, name: str, const_labels: LabelsType
+    ) -> pmp.Metric:
+        """
         :param histogram: a 2-tuple containing labels and a dict representing
           the histogram value. The dict contains keys for each bucket as
           well as the sum and count fields.
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
         histogram_labels, histogram_value_dict = histogram
         # typing check, no runtime behaviour.
         histogram_value_dict = cast(HistogramDictType, histogram_value_dict)
 
         metric = pmp.utils.create_histogram_metric(
-            histogram_labels, histogram_value_dict,
-            samples_count=histogram_value_dict['count'],
-            samples_sum=histogram_value_dict['sum'],
+            histogram_labels,
+            histogram_value_dict,
+            samples_count=histogram_value_dict["count"],
+            samples_sum=histogram_value_dict["sum"],
             timestamp=self.timestamp,
             const_labels=const_labels,
-            ordered=True)
+            ordered=True,
+        )
 
         return metric
 
-    def marshall_collector(self,
-                           collector: CollectorsType) -> pmp.MetricFamily:
-        '''
+    def marshall_collector(self, collector: CollectorsType) -> pmp.MetricFamily:
+        """
         Marshalls a collector into a :class:`MetricFamily` object representing
         the metrics in the collector.
 
         :return: a :class:`MetricFamily` object
-        '''
+        """
         exec_method = None  # type: FormatterFuncType
         if isinstance(collector, Counter):
             metric_type = pmp.COUNTER
@@ -171,19 +176,20 @@ class BinaryFormatter(IFormatter):
             metrics.append(r)
 
         mf = pmp.utils.create_metric_family(
-            collector.name, collector.doc, metric_type, metrics)
+            collector.name, collector.doc, metric_type, metrics
+        )
 
         return mf
 
     def marshall(self, registry: CollectorRegistry) -> bytes:
-        ''' Marshall the collectors in the registry into binary protocol
+        """ Marshall the collectors in the registry into binary protocol
         buffer format.
 
         The Prometheus metrics parser expects each metric (MetricFamily) to
         be prefixed with a varint containing the size of the encoded metric.
 
         :returns: bytes
-        '''
+        """
         buf = bytearray()
         for i in registry.get_all():
             buf.extend(pmp.encode(self.marshall_collector(i)))

--- a/src/aioprometheus/formats/text.py
+++ b/src/aioprometheus/formats/text.py
@@ -1,4 +1,4 @@
-''' This module implements a Prometheus metrics text formatter '''
+""" This module implements a Prometheus metrics text formatter """
 
 import collections
 
@@ -26,7 +26,7 @@ FormatterFuncType = Callable[[MetricTupleType, str, LabelsType], List[str]]
 HELP_FMT = "# HELP {name} {doc}"
 TYPE_FMT = "# TYPE {name} {kind}"
 COMMENT_FMT = "# {comment}"
-LABEL_FMT = "{key}=\"{value}\""
+LABEL_FMT = '{key}="{value}"'
 LABEL_SEPARATOR_FMT = ","
 LINE_SEPARATOR_FMT = "\n"
 METRIC_FMT = "{name}{labels} {value} {timestamp}"
@@ -34,36 +34,36 @@ POS_INF = float("inf")
 NEG_INF = float("-inf")
 
 
-TEXT_CONTENT_TYPE = 'text/plain; version=0.0.4; charset=utf-8'
+TEXT_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 
 
 class TextFormatter(IFormatter):
-    ''' This formatter encodes into the Protocol Buffers binary format '''
+    """ This formatter encodes into the Protocol Buffers binary format """
 
     def __init__(self, timestamp: bool = False) -> None:
-        ''' Initialise the text formatter.
+        """ Initialise the text formatter.
 
         timestamp is a boolean, if you want timestamp in each metric.
-        '''
+        """
         self.timestamp = timestamp
-        self._headers = {'Content-Type': TEXT_CONTENT_TYPE}
+        self._headers = {"Content-Type": TEXT_CONTENT_TYPE}
 
     def get_headers(self) -> Dict[str, str]:
         return self._headers
 
-    def _format_line(self,
-                     name: str,
-                     labels: LabelsType,
-                     value: NumericValueType,
-                     const_labels: LabelsType = None) -> str:
+    def _format_line(
+        self,
+        name: str,
+        labels: LabelsType,
+        value: NumericValueType,
+        const_labels: LabelsType = None,
+    ) -> str:
 
         labels = self._unify_labels(labels, const_labels, True)
 
         labels_str = ""  # type: str
         if labels:
-            _labels = [
-                LABEL_FMT.format(key=k, value=v)
-                for k, v in labels.items()]
+            _labels = [LABEL_FMT.format(key=k, value=v) for k, v in labels.items()]
             labels_str = LABEL_SEPARATOR_FMT.join(_labels)
             labels_str = "{{{labels}}}".format(labels=labels_str)
 
@@ -72,52 +72,50 @@ class TextFormatter(IFormatter):
             ts = self._get_timestamp()
 
         result = METRIC_FMT.format(
-            name=name, labels=labels_str, value=value, timestamp=ts)
+            name=name, labels=labels_str, value=value, timestamp=ts
+        )
 
         return result.strip()
 
-    def _format_counter(self,
-                        counter: MetricTupleType,
-                        name: str,
-                        const_labels: LabelsType) -> List[str]:
-        '''
+    def _format_counter(
+        self, counter: MetricTupleType, name: str, const_labels: LabelsType
+    ) -> List[str]:
+        """
         :param counter: a 2-tuple containing labels and the counter value.
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
         labels, value = counter
         value = cast(NumericValueType, value)  # typing check, no runtime behaviour.
         line = self._format_line(name, labels, value, const_labels)
         return [line]
 
-    def _format_gauge(self,
-                      gauge: MetricTupleType,
-                      name: str,
-                      const_labels: LabelsType) -> List[str]:
-        '''
+    def _format_gauge(
+        self, gauge: MetricTupleType, name: str, const_labels: LabelsType
+    ) -> List[str]:
+        """
         :param gauge: a 2-tuple containing labels and the gauge value.
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
         labels, value = gauge
         value = cast(NumericValueType, value)  # typing check, no runtime behaviour.
         line = self._format_line(name, labels, value, const_labels)
         return [line]
 
-    def _format_summary(self,
-                        summary: MetricTupleType,
-                        name: str,
-                        const_labels: LabelsType) -> List[str]:
-        '''
+    def _format_summary(
+        self, summary: MetricTupleType, name: str, const_labels: LabelsType
+    ) -> List[str]:
+        """
         :param summary: a 2-tuple containing labels and a dict representing
           the summary value. The dict contains keys for each quantile as
           well as the sum and count fields.
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
         summary_labels, summary_value_dict = summary
         # typing check, no runtime behaviour.
         summary_value_dict = cast(SummaryDictType, summary_value_dict)
@@ -133,25 +131,23 @@ class TextFormatter(IFormatter):
             if type(k) is not float:
                 name_str = "{0}_{1}".format(name, k)
             else:
-                labels['quantile'] = str(k)
+                labels["quantile"] = str(k)
                 name_str = name
-            results.append(
-                self._format_line(name_str, labels, v, const_labels))
+            results.append(self._format_line(name_str, labels, v, const_labels))
 
         return results
 
-    def _format_histogram(self,
-                          histogram: MetricTupleType,
-                          name: str,
-                          const_labels: LabelsType) -> List[str]:
-        '''
+    def _format_histogram(
+        self, histogram: MetricTupleType, name: str, const_labels: LabelsType
+    ) -> List[str]:
+        """
         :param histogram: a 2-tuple containing labels and a dict representing
           the histogram value. The dict contains keys for each bucket as
           well as the sum and count fields.
         :param name: the metric name.
         :param const_labels: a dict of constant labels to be associated with
           the metric.
-        '''
+        """
         histogram_labels, histogram_value_dict = histogram
         # typing check, no runtime behaviour.
         histogram_value_dict = cast(HistogramDictType, histogram_value_dict)
@@ -169,25 +165,24 @@ class TextFormatter(IFormatter):
             else:
                 upper_bound = k
                 if upper_bound == POS_INF:
-                    upper_bound = '+Inf'
+                    upper_bound = "+Inf"
                 elif upper_bound == NEG_INF:
-                    upper_bound = '-Inf'
+                    upper_bound = "-Inf"
                 # Add the le ("less or equal") label.
-                labels['le'] = str(upper_bound)
+                labels["le"] = str(upper_bound)
                 # Use the special bucket label name
-                name_str = name + '_bucket'
-            results.append(
-                self._format_line(name_str, labels, v, const_labels))
+                name_str = name + "_bucket"
+            results.append(self._format_line(name_str, labels, v, const_labels))
 
         return results
 
     def marshall_lines(self, collector: CollectorsType) -> List[str]:
-        '''
+        """
         Marshalls a collector into a sequence of strings representing
         the metrics in the collector.
 
         :return: a list of strings.
-        '''
+        """
         exec_method = None  # type: FormatterFuncType
         if isinstance(collector, Counter):
             exec_method = self._format_counter
@@ -201,11 +196,9 @@ class TextFormatter(IFormatter):
             raise TypeError("Not a valid object format")
 
         # create headers
-        help_header = HELP_FMT.format(
-            name=collector.name, doc=collector.doc)
+        help_header = HELP_FMT.format(name=collector.name, doc=collector.doc)
 
-        type_header = TYPE_FMT.format(
-            name=collector.name, kind=collector.kind.name)
+        type_header = TYPE_FMT.format(name=collector.name, kind=collector.kind.name)
 
         # Prepare start headers
         lines = [help_header, type_header]
@@ -218,16 +211,16 @@ class TextFormatter(IFormatter):
         return lines
 
     def marshall_collector(self, collector: CollectorsType) -> str:
-        '''
+        """
         Marshalls a collector into a string containing one or more lines
-        '''
+        """
         # need sort?
         result = sorted(self.marshall_lines(collector))
         return LINE_SEPARATOR_FMT.join(result)
 
     def marshall(self, registry: CollectorRegistry) -> bytes:
-        ''' Marshalls a registry (containing collectors) into a bytes
-        object '''
+        """ Marshalls a registry (containing collectors) into a bytes
+        object """
 
         blocks = []
         for i in registry.get_all():
@@ -239,4 +232,4 @@ class TextFormatter(IFormatter):
         # Needs EOF
         blocks.append("")
 
-        return LINE_SEPARATOR_FMT.join(blocks).encode('utf-8')
+        return LINE_SEPARATOR_FMT.join(blocks).encode("utf-8")

--- a/src/aioprometheus/histogram.py
+++ b/src/aioprometheus/histogram.py
@@ -9,26 +9,26 @@ NEG_INF = float("-inf")
 BucketType = float
 
 
-def linearBuckets(start: Union[float, int],
-                  width: Union[int, float],
-                  count: int) -> List[BucketType]:
-    ''' Returns buckets that are spaced linearly.
+def linearBuckets(
+    start: Union[float, int], width: Union[int, float], count: int
+) -> List[BucketType]:
+    """ Returns buckets that are spaced linearly.
 
     Returns ``count`` buckets, each ``width`` wide, where the lowest bucket
     has an upper bound of ``start``. There is no +Inf bucket is included in
     the returned list.
 
     :raises: Exception if ``count`` is zero or negative.
-    '''
+    """
     if count < 1:
-        raise Exception('Invalid count, must be a positive number')
+        raise Exception("Invalid count, must be a positive number")
     return [start + i * width for i in range(count)]
 
 
-def exponentialBuckets(start: Union[float, int],
-                       factor: Union[float, int],
-                       count: int) -> List[BucketType]:
-    ''' Returns buckets that are spaced exponentially.
+def exponentialBuckets(
+    start: Union[float, int], factor: Union[float, int], count: int
+) -> List[BucketType]:
+    """ Returns buckets that are spaced exponentially.
 
     Returns ``count`` buckets, where the lowest bucket has an upper bound of
     ``start`` and each following bucket's upper bound is ``factor`` times the
@@ -38,50 +38,49 @@ def exponentialBuckets(start: Union[float, int],
     :raises: Exception if ``count`` is 0 or negative.
     :raises: Exception if ``start`` is 0 or negative,
     :raises: Exception if ``factor`` is less than or equal 1.
-    '''
+    """
 
     if count < 1:
-        raise Exception('Invalid count, must be a positive number')
+        raise Exception("Invalid count, must be a positive number")
     if start <= 0:
-        raise Exception('Invalid start, must be positive')
+        raise Exception("Invalid start, must be positive")
     if factor < 1:
-        raise Exception('Invalid factor, must be greater than one')
+        raise Exception("Invalid factor, must be greater than one")
     return [start * (i * factor) for i in range(count)]
 
 
 class Histogram(object):
-    '''
+    """
     A Histogram counts individual observations from an event into configurable
     buckets. This histogram implementation also provides a sum and count of
     observations.
-    '''
+    """
 
     def __init__(self, *buckets: BucketType) -> None:
         _buckets = [float(b) for b in buckets]
 
         if _buckets != sorted(buckets):
-            raise ValueError('Buckets not in sorted order')
+            raise ValueError("Buckets not in sorted order")
 
         if _buckets and _buckets[-1] != POS_INF:
             _buckets.append(POS_INF)
 
         if len(_buckets) < 2:
-            raise ValueError('Must have at least two buckets')
+            raise ValueError("Must have at least two buckets")
 
-        self.buckets = OrderedDict(
-            [(b, 0) for b in _buckets])  # type: Dict[float, int]
+        self.buckets = OrderedDict([(b, 0) for b in _buckets])  # type: Dict[float, int]
         self.observations = 0  # type: int
         self.sum = 0.0  # type: float
 
     def observe(self, value: Union[float, int]) -> None:
-        ''' Observe the given amount.
+        """ Observe the given amount.
 
         Observing a value into the histogram will increment the count of
         observations, add the value to the sum of all observations and
         increment the appropriate bucket counter.
 
         :param value: A metric value to add to the histogram.
-        '''
+        """
         # The last bucket is +Inf, so we will always increment at least
         # one bucket
         for upper_bound in self.buckets:

--- a/src/aioprometheus/metricdict.py
+++ b/src/aioprometheus/metricdict.py
@@ -10,10 +10,10 @@ regex = re.compile(r"\{.*:.*,?\}")
 
 # http://stackoverflow.com/questions/3387691/python-how-to-perfectly-override-a-dict
 class MetricDict(collections.MutableMapping):
-    '''
+    """
     MetricDict stores the data based on the labels so we need to generate
     custom hash keys based on the labels
-    '''
+    """
 
     EMPTY_KEY = "__EMPTY__"
 

--- a/src/aioprometheus/negotiator.py
+++ b/src/aioprometheus/negotiator.py
@@ -11,12 +11,12 @@ logger = logging.getLogger(__name__)
 FormatterType = Callable[[bool], formats.IFormatter]
 
 
-ProtobufAccepts = set(formats.BINARY_CONTENT_TYPE.split('; '))
-TextAccepts = set(formats.TEXT_CONTENT_TYPE.split('; '))
+ProtobufAccepts = set(formats.BINARY_CONTENT_TYPE.split("; "))
+TextAccepts = set(formats.TEXT_CONTENT_TYPE.split("; "))
 
 
 def negotiate(accepts: Set[str]) -> FormatterType:
-    ''' Negotiate a response format by scanning through the ACCEPTS
+    """ Negotiate a response format by scanning through the ACCEPTS
     header and selecting the most efficient format.
 
     The formatter returned by this function is used to render a response.
@@ -25,18 +25,15 @@ def negotiate(accepts: Set[str]) -> FormatterType:
 
     :returns: a formatter class to form up the response into the
       appropriate representation.
-    '''
+    """
     if not isinstance(accepts, set):
-        raise TypeError(
-            'Expected a set but got {}'.format(type(accepts)))
+        raise TypeError("Expected a set but got {}".format(type(accepts)))
 
     formatter = formats.TextFormatter  # type: FormatterType
 
     if ProtobufAccepts.issubset(accepts):
         formatter = formats.BinaryFormatter  # type: ignore
 
-    logger.debug(
-        'negotiating %s resulted in choosing %s',
-        accepts, formatter.__name__)
+    logger.debug("negotiating %s resulted in choosing %s", accepts, formatter.__name__)
 
     return formatter

--- a/src/aioprometheus/pusher.py
+++ b/src/aioprometheus/pusher.py
@@ -13,19 +13,16 @@ from .registry import CollectorRegistry
 
 
 class Pusher(object):
-    '''
+    """
     This class can be used in applications that can't support the
     standard pull strategy. The pusher object pushes the metrics
     to a push-gateway which can be scraped by Prometheus.
-    '''
+    """
 
     PATH = "/metrics/job/{0}"
 
-    def __init__(self,
-                 job_name: str,
-                 addr: str,
-                 loop: BaseEventLoop = None) -> None:
-        '''
+    def __init__(self, job_name: str, addr: str, loop: BaseEventLoop = None) -> None:
+        """
 
         :param job_name: The name of the job.
 
@@ -35,7 +32,7 @@ class Pusher(object):
 
         :param loop: The event loop instance to use. If no loop is specified
           then the default event loop will be used.
-        '''
+        """
         self.job_name = job_name
         self.addr = addr
         self.loop = loop or asyncio.get_event_loop()
@@ -43,22 +40,19 @@ class Pusher(object):
         self.headers = self.formatter.get_headers()
         self.path = urljoin(self.addr, self.PATH.format(job_name))
 
-    async def add(self,
-                  registry: CollectorRegistry) -> aiohttp.web.Response:
-        '''
+    async def add(self, registry: CollectorRegistry) -> aiohttp.web.Response:
+        """
         ``add`` works like replace, but only metrics with the same name as the
         newly pushed metrics are replaced.
-        '''
+        """
         async with aiohttp.ClientSession() as session:
             payload = self.formatter.marshall(registry)
-            resp = await session.post(
-                self.path, data=payload, headers=self.headers)
+            resp = await session.post(self.path, data=payload, headers=self.headers)
         await resp.release()
         return resp
 
-    async def replace(self,
-                      registry: CollectorRegistry) -> aiohttp.web.Response:
-        '''
+    async def replace(self, registry: CollectorRegistry) -> aiohttp.web.Response:
+        """
         ``replace`` pushes new values for a group of metrics to the push
         gateway.
 
@@ -67,23 +61,20 @@ class Pusher(object):
             All existing metrics with the same grouping key specified in the
             URL will be replaced with the new metrics value.
 
-        '''
+        """
         async with aiohttp.ClientSession() as session:
             payload = self.formatter.marshall(registry)
-            resp = await session.put(
-                self.path, data=payload, headers=self.headers)
+            resp = await session.put(self.path, data=payload, headers=self.headers)
         await resp.release()
         return resp
 
-    async def delete(self,
-                     registry: CollectorRegistry) -> aiohttp.web.Response:
-        '''
+    async def delete(self, registry: CollectorRegistry) -> aiohttp.web.Response:
+        """
         ``delete`` deletes metrics from the push gateway. All metrics with
         the grouping key specified in the URL are deleted.
-        '''
+        """
         async with aiohttp.ClientSession() as session:
             payload = self.formatter.marshall(registry)
-            resp = await session.delete(
-                self.path, data=payload, headers=self.headers)
+            resp = await session.delete(self.path, data=payload, headers=self.headers)
         await resp.release()
         return resp

--- a/src/aioprometheus/registry.py
+++ b/src/aioprometheus/registry.py
@@ -6,19 +6,19 @@ CollectorsType = Union[Counter, Gauge, Histogram, Summary]
 
 
 class CollectorRegistry(object):
-    ''' This class implements the metrics collector registry.
+    """ This class implements the metrics collector registry.
 
     Collectors in the registry must comply with the Collector interface
     which means that they inherit from the base Collector object and implement
     a no-argument method called 'get_all' that returns a list of Metric
     instance objects.
-    '''
+    """
 
     def __init__(self) -> None:
         self.collectors = {}  # type: Dict[str, CollectorsType]
 
     def register(self, collector: CollectorsType) -> None:
-        ''' Register a collector.
+        """ Register a collector.
 
         This will allow the collector metrics to be emitted.
 
@@ -28,40 +28,39 @@ class CollectorRegistry(object):
           :class:`Collector`.
 
         :raises: ValueError if collector is already registered.
-        '''
+        """
         if not isinstance(collector, Collector):
-            raise TypeError(
-                'Invalid collector type: {}'.format(collector))
+            raise TypeError("Invalid collector type: {}".format(collector))
 
         if collector.name in self.collectors:
             raise ValueError(
-                "Collector {} is already registered".format(
-                    collector.name))
+                "Collector {} is already registered".format(collector.name)
+            )
 
         self.collectors[collector.name] = collector
 
     def deregister(self, name: str) -> None:
-        ''' Deregister a collector.
+        """ Deregister a collector.
 
         This will stop the collector metrics from being emitted.
 
         :param name: The name of the collector to deregister.
 
         :raises: KeyError if collector is not already registered.
-        '''
+        """
         del self.collectors[name]
 
     def get(self, name: str) -> CollectorsType:
-        ''' Get a collector by name.
+        """ Get a collector by name.
 
         :param name: The name of the collector to fetch.
 
         :raises: KeyError if collector is not found.
-        '''
+        """
         return self.collectors[name]
 
     def get_all(self) -> List[CollectorsType]:
-        ''' Return a list of all collectors '''
+        """ Return a list of all collectors """
         return list(self.collectors.values())
 
 

--- a/src/aioprometheus/service.py
+++ b/src/aioprometheus/service.py
@@ -1,6 +1,6 @@
-'''
+"""
 This module implements an asynchronous Prometheus metrics service.
-'''
+"""
 
 import asyncio
 import logging
@@ -8,9 +8,7 @@ import socket
 import aiohttp
 import aiohttp.web
 
-from aiohttp.hdrs import (
-    METH_GET as GET,
-    ACCEPT)
+from aiohttp.hdrs import METH_GET as GET, ACCEPT
 
 from .negotiator import negotiate
 from .registry import Registry, CollectorsType
@@ -23,20 +21,18 @@ from ssl import SSLContext
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_METRICS_PATH = '/metrics'
+DEFAULT_METRICS_PATH = "/metrics"
 
 
 class Service(object):
-    '''
+    """
     This class implements a Prometheus metrics service that can
     be embedded within asyncio based applications so they can be scraped
     by the Prometheus.io server.
-    '''
+    """
 
-    def __init__(self,
-                 registry: Registry = None,
-                 loop: BaseEventLoop = None) -> None:
-        '''
+    def __init__(self, registry: Registry = None, loop: BaseEventLoop = None) -> None:
+        """
         Initialise the Prometheus metrics service.
 
         :param registry: A :class:`CollectorRegistry` instance that will
@@ -48,68 +44,71 @@ class Service(object):
 
         :raises: Exception if the registry object is not an instance of the
           Registry type.
-        '''
+        """
         self.loop = loop or asyncio.get_event_loop()
         if registry is not None and not isinstance(registry, Registry):
-            raise Exception(
-                'registry must be a Registry, got: {}'.format(registry))
+            raise Exception("registry must be a Registry, got: {}".format(registry))
         self.registry = registry or Registry()
         self._svr = None  # type: Server
         self._svc = None  # type: aiohttp.web.Application
         self._handler = None  # type: aiohttp.web.RequestHandlerFactory
         self._https = None  # type: bool
-        self._root_url = '/'
+        self._root_url = "/"
         self._metrics_url = None  # type: str
 
     @property
     def base_url(self) -> str:
-        ''' Return the base service url
+        """ Return the base service url
 
         :raises: Exception if the server has not been started.
 
         :return: the base service URL as a string
-        '''
+        """
         if self._svr is None:
             raise Exception(
-                "No URL available, Prometheus metrics server is not running")
+                "No URL available, Prometheus metrics server is not running"
+            )
 
         # IPv4 returns 2-tuple, IPv6 returns 4-tuple
         host, port, *_ = self._svr.sockets[0].getsockname()
-        scheme = "http{}".format('s' if self._https else '')
+        scheme = "http{}".format("s" if self._https else "")
         url = "{scheme}://{host}:{port}".format(
             scheme=scheme,
             host=host if ":" not in host else "[{}]".format(host),
-            port=port)
+            port=port,
+        )
         return url
 
     @property
     def root_url(self) -> str:
-        ''' Return the root service url
+        """ Return the root service url
 
         :raises: Exception if the server has not been started.
 
         :return: the root URL as a string
-        '''
-        return f'{self.base_url}{self._root_url}'
+        """
+        return f"{self.base_url}{self._root_url}"
 
     @property
     def metrics_url(self) -> str:
-        ''' Return the Prometheus metrics url
+        """ Return the Prometheus metrics url
 
         :raises: Exception if the server has not been started.
 
         :return: the metrics URL as a string
-        '''
-        return f'{self.base_url}{self._metrics_url}'
+        """
+        return f"{self.base_url}{self._metrics_url}"
 
-    async def start(self,
-                    addr: str = '',
-                    port: int = 0,
-                    family: socket.AddressFamily = socket.AF_INET,
-                    ssl: SSLContext = None,
-                    metrics_url: str = DEFAULT_METRICS_PATH,
-                    discovery_agent=None) -> None:
-        ''' Start the prometheus metrics HTTP(S) server.
+    async def start(
+        self,
+        addr: str = "",
+        port: int = 0,
+        family: socket.AddressFamily = socket.AF_INET,
+        ssl: SSLContext = None,
+        metrics_url: str = DEFAULT_METRICS_PATH,
+        discovery_agent=None,
+    ) -> None:
+        """ Start the prometheus metrics HTTP(S) server.
 
         :param addr: the address to bind the server on. By default this is
           set to an empty string so that the service becomes available on
@@ -132,44 +131,39 @@ class Service(object):
           service with a service discovery mechanism.
 
         :raises: Exception if the server could not be started.
-        '''
+        """
         logger.debug(
-            'Prometheus metrics server starting on %s:%s%s',
-            addr, port, metrics_url)
+            "Prometheus metrics server starting on %s:%s%s", addr, port, metrics_url
+        )
 
         if self._svr:
-            logger.warning(
-                'Prometheus metrics server is already running')
+            logger.warning("Prometheus metrics server is already running")
             return
 
         self._svc = aiohttp.web.Application()
         self._metrics_url = metrics_url
-        self._svc['metrics_url'] = metrics_url
-        self._svc.router.add_route(
-            GET, metrics_url, self.handle_metrics)
-        self._svc.router.add_route(
-            GET, self._root_url, self.handle_root)
-        self._svc.router.add_route(
-            GET, '/robots.txt', self.handle_robots)
+        self._svc["metrics_url"] = metrics_url
+        self._svc.router.add_route(GET, metrics_url, self.handle_metrics)
+        self._svc.router.add_route(GET, self._root_url, self.handle_root)
+        self._svc.router.add_route(GET, "/robots.txt", self.handle_robots)
         self._handler = self._svc.make_handler()
         self._https = ssl is not None
         try:
             self._svr = await self.loop.create_server(
-                self._handler, addr, port, family=family, ssl=ssl)
+                self._handler, addr, port, family=family, ssl=ssl
+            )
         except Exception:
-            logger.exception('error creating metrics server')
+            logger.exception("error creating metrics server")
             raise
 
-        logger.debug('Prometheus metrics server started on %s', self.metrics_url)
+        logger.debug("Prometheus metrics server started on %s", self.metrics_url)
 
         # register service with service discovery
         if discovery_agent:
             await discovery_agent.register(self)
 
-    async def stop(self,
-                   wait_duration: float = 1.0,
-                   discovery_agent=None) -> None:
-        ''' Stop the prometheus metrics HTTP(S) server.
+    async def stop(self, wait_duration: float = 1.0, discovery_agent=None) -> None:
+        """ Stop the prometheus metrics HTTP(S) server.
 
         :param wait_duration: the number of seconds to wait for connections to
           finish.
@@ -177,13 +171,11 @@ class Service(object):
         :param discovery_agent: an agent that can deregister the metrics
           service from a service discovery mechanism.
 
-        '''
-        logger.debug(
-            'Prometheus metrics server stopping')
+        """
+        logger.debug("Prometheus metrics server stopping")
 
         if self._svr is None:
-            logger.warning(
-                'Prometheus metrics server is already stopped')
+            logger.warning("Prometheus metrics server is already stopped")
             return
 
         # de-register service with service discovery
@@ -200,31 +192,32 @@ class Service(object):
         self._svr = None
         self._svc = None
         self._handler = None
-        logger.debug('Prometheus metrics server stopped')
+        logger.debug("Prometheus metrics server stopped")
 
     def register(self, collector: CollectorsType) -> None:
-        ''' Register a collector.
+        """ Register a collector.
 
         :raises: TypeError if collector is not an instance of
           :class:`Collector`.
         :raises: ValueError if collector is already registered.
-        '''
+        """
         self.registry.register(collector)
 
     def deregister(self, name: str) -> None:
-        ''' Deregister a collector.
+        """ Deregister a collector.
 
         :param name: A collector name to deregister.
-        '''
+        """
         self.registry.deregister(name)
 
-    async def handle_metrics(self,
-                             request: aiohttp.web.Request) -> aiohttp.web.Response:
-        ''' Handle a request to the metrics route.
+    async def handle_metrics(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        """ Handle a request to the metrics route.
 
         The request is inspected and the most efficient response data format
         is chosen.
-        '''
+        """
         Formatter = negotiate(self.accepts(request))
         formatter = Formatter(False)
 
@@ -233,38 +226,37 @@ class Service(object):
         resp.body = formatter.marshall(self.registry)
         return resp
 
-    def accepts(self,
-                request: aiohttp.web.Request) -> Set[str]:
-        ''' Return a sequence of accepts items in the request headers '''
+    def accepts(self, request: aiohttp.web.Request) -> Set[str]:
+        """ Return a sequence of accepts items in the request headers """
         accepts = set()  # type: Set[str]
         accept_headers = request.headers.getall(ACCEPT, [])
-        logger.debug('accept: {}'.format(accept_headers))
+        logger.debug("accept: {}".format(accept_headers))
         for accept_items in accept_headers:
-            if ';' in accept_items:
-                accept_items = [i.strip() for i in accept_items.split(';')]
+            if ";" in accept_items:
+                accept_items = [i.strip() for i in accept_items.split(";")]
             else:
                 accept_items = [accept_items]
             accepts.update(accept_items)
         return accepts
 
-    async def handle_root(self,
-                          request: aiohttp.web.Request) -> aiohttp.web.Response:
-        ''' Handle a request to the / route.
+    async def handle_root(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        """ Handle a request to the / route.
 
         Serves a trivial page with a link to the metrics.  Use this if ever
         you need to point a health check at your the service.
-        '''
+        """
         return aiohttp.web.Response(
             content_type="text/html",
             text="<html><body><a href='{}'>metrics</a></body></html>".format(
-                request.app['metrics_url']))
+                request.app["metrics_url"]
+            ),
+        )
 
-    async def handle_robots(self,
-                            request: aiohttp.web.Request) -> aiohttp.web.Response:
-        ''' Handle a request to /robots.txt
+    async def handle_robots(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
+        """ Handle a request to /robots.txt
 
         If a robot ever stumbles on this server, discourage it from indexing.
-        '''
+        """
         return aiohttp.web.Response(
-            content_type="text/plain",
-            text="User-agent: *\nDisallow: /\n")
+            content_type="text/plain", text="User-agent: *\nDisallow: /\n"
+        )

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -7,143 +7,148 @@ from aioprometheus import (
     Summary,
     timer,
     inprogress,
-    count_exceptions)
+    count_exceptions,
+)
 
 
 class TestDecorators(asynctest.TestCase):
 
     async def test_timer(self):
-        m = Summary('metric_label', 'metric help')
+        m = Summary("metric_label", "metric help")
 
         # decorator should work methods as well as functions
-        @timer(m, {'kind': 'function'})
+        @timer(m, {"kind": "function"})
         async def a():
             return
 
         await a()
 
-        m_function = m.get({'kind': 'function'})
-        self.assertEqual(m_function['count'], 1)
+        m_function = m.get({"kind": "function"})
+        self.assertEqual(m_function["count"], 1)
 
         # decorator should work methods as well as functions
         class B(object):
 
-            @timer(m, {'kind': 'method'})
+            @timer(m, {"kind": "method"})
             async def b(self, arg1, arg2=None):
-                return arg1 == 'b_arg', arg2 == 'arg_2'
+                return arg1 == "b_arg", arg2 == "arg_2"
 
         b = B()
-        results = await b.b('b_arg', arg2='arg_2')
+        results = await b.b("b_arg", arg2="arg_2")
         self.assertTrue(all(results))
 
-        m_method = m.get({'kind': 'method'})
-        self.assertEqual(m_method['count'], 1)
+        m_method = m.get({"kind": "method"})
+        self.assertEqual(m_method["count"], 1)
 
         # Only Summary metric type can be used with @timer, others should
         # raise an exception.
         with self.assertRaises(Exception) as cm:
-            m = Counter('metric_label', 'metric help')
+            m = Counter("metric_label", "metric help")
 
             @timer(m)
             async def c():
                 return
+
         self.assertIn(
-            "timer decorator expects a Summary metric but got:",
-            str(cm.exception))
+            "timer decorator expects a Summary metric but got:", str(cm.exception)
+        )
 
     async def test_inprogress(self):
-        m = Gauge('metric_label', 'metric help')
+        m = Gauge("metric_label", "metric help")
 
         # decorator should work methods as well as functions
-        @inprogress(m, {'kind': 'function'})
+        @inprogress(m, {"kind": "function"})
         async def a():
             return
 
         await a()
 
-        m_function_value = m.get({'kind': 'function'})
+        m_function_value = m.get({"kind": "function"})
         self.assertEqual(m_function_value, 0)
 
         # decorator should work methods as well as functions
         class B(object):
 
-            @inprogress(m, {'kind': 'method'})
+            @inprogress(m, {"kind": "method"})
             async def b(self, arg1, arg2=None):
-                return arg1 == 'b_arg', arg2 == 'arg_2'
+                return arg1 == "b_arg", arg2 == "arg_2"
 
         b = B()
-        results = await b.b('b_arg', arg2='arg_2')
+        results = await b.b("b_arg", arg2="arg_2")
         self.assertTrue(all(results))
 
-        m_method_value = m.get({'kind': 'method'})
+        m_method_value = m.get({"kind": "method"})
         self.assertEqual(m_method_value, 0)
 
         # Only Gauge metric type can be used with @timer, others should
         # raise an exception.
         with self.assertRaises(Exception) as cm:
-            m = Counter('metric_label', 'metric help')
+            m = Counter("metric_label", "metric help")
 
             @inprogress(m)
             async def c():
                 return
+
         self.assertIn(
-            "inprogess decorator expects a Gauge metric but got:",
-            str(cm.exception))
+            "inprogess decorator expects a Gauge metric but got:", str(cm.exception)
+        )
 
     async def test_count_exceptions(self):
-        m = Counter('metric_label', 'metric help')
+        m = Counter("metric_label", "metric help")
 
         # decorator should work methods as well as functions
-        @count_exceptions(m, {'kind': 'function'})
+        @count_exceptions(m, {"kind": "function"})
         async def a(raise_exc=False):
             if raise_exc:
-                raise Exception('dummy exception')
+                raise Exception("dummy exception")
             return
 
         await a()
 
         # metric should not exist until an exception occurs
         with self.assertRaises(KeyError):
-            m.get({'kind': 'function'})
+            m.get({"kind": "function"})
 
         with self.assertRaises(Exception) as cm:
             await a(True)
         self.assertIn("dummy exception", str(cm.exception))
 
-        m_function_value = m.get({'kind': 'function'})
+        m_function_value = m.get({"kind": "function"})
         self.assertEqual(m_function_value, 1)
 
         # decorator should work methods as well as functions
         class B(object):
 
-            @count_exceptions(m, {'kind': 'method'})
+            @count_exceptions(m, {"kind": "method"})
             async def b(self, arg1, arg2=None, raise_exc=False):
                 if raise_exc:
-                    raise Exception('dummy exception')
-                return arg1 == 'b_arg', arg2 == 'arg_2'
+                    raise Exception("dummy exception")
+                return arg1 == "b_arg", arg2 == "arg_2"
 
         b = B()
 
-        results = await b.b('b_arg', arg2='arg_2')
+        results = await b.b("b_arg", arg2="arg_2")
         self.assertTrue(all(results))
         # metric should not exist until an exception occurs
         with self.assertRaises(KeyError):
-            m.get({'kind': 'method'})
+            m.get({"kind": "method"})
 
         with self.assertRaises(Exception) as cm:
-            await b.b('b_arg', arg2='arg_2', raise_exc=True)
+            await b.b("b_arg", arg2="arg_2", raise_exc=True)
         self.assertIn("dummy exception", str(cm.exception))
-        m_method_value = m.get({'kind': 'method'})
+        m_method_value = m.get({"kind": "method"})
         self.assertEqual(m_method_value, 1)
 
         # Only Gauge metric type can be used with @timer, others should
         # raise an exception.
         with self.assertRaises(Exception) as cm:
-            m = Histogram('metric_label', 'metric help')
+            m = Histogram("metric_label", "metric help")
 
             @count_exceptions(m)
             async def c():
                 return
+
         self.assertIn(
             "count_exceptions decorator expects a Counter metric but got:",
-            str(cm.exception))
+            str(cm.exception),
+        )

--- a/tests/test_formats_binary.py
+++ b/tests/test_formats_binary.py
@@ -4,8 +4,7 @@ import unittest
 import unittest.mock
 import prometheus_metrics_proto as pmp
 from aioprometheus.formats import BinaryFormatter, BINARY_CONTENT_TYPE
-from aioprometheus import (
-    Collector, Counter, Gauge, Histogram, Summary, Registry)
+from aioprometheus import Collector, Counter, Gauge, Histogram, Summary, Registry
 
 
 TEST_TIMESTAMP = 1515044377268
@@ -18,63 +17,64 @@ class TestProtobufFormat(unittest.TestCase):
         self.const_labels = {"app": "my_app"}
 
         # Counter test fields
-        self.counter_metric_name = 'logged_users_total'
-        self.counter_metric_help = 'Logged users in the application.'
+        self.counter_metric_name = "logged_users_total"
+        self.counter_metric_help = "Logged users in the application."
         self.counter_metric_data = (
-            ({'country': "sp", "device": "desktop"}, 520),
-            ({'country': "us", "device": "mobile"}, 654),
-            ({'country': "uk", "device": "desktop"}, 1001),
-            ({'country': "de", "device": "desktop"}, 995),
-            ({'country': "zh", "device": "desktop"}, 520),
+            ({"country": "sp", "device": "desktop"}, 520),
+            ({"country": "us", "device": "mobile"}, 654),
+            ({"country": "uk", "device": "desktop"}, 1001),
+            ({"country": "de", "device": "desktop"}, 995),
+            ({"country": "zh", "device": "desktop"}, 520),
         )
 
         # Gauge test fields
-        self.gauge_metric_name = 'logged_users_total'
-        self.gauge_metric_help = 'Logged users in the application.'
+        self.gauge_metric_name = "logged_users_total"
+        self.gauge_metric_help = "Logged users in the application."
         self.gauge_metric_data = (
-            ({'country': "sp", "device": "desktop"}, 520),
-            ({'country': "us", "device": "mobile"}, 654),
-            ({'country': "uk", "device": "desktop"}, 1001),
-            ({'country': "de", "device": "desktop"}, 995),
-            ({'country': "zh", "device": "desktop"}, 520),
+            ({"country": "sp", "device": "desktop"}, 520),
+            ({"country": "us", "device": "mobile"}, 654),
+            ({"country": "uk", "device": "desktop"}, 1001),
+            ({"country": "de", "device": "desktop"}, 995),
+            ({"country": "zh", "device": "desktop"}, 520),
         )
 
         # Summary test fields
-        self.summary_metric_name = 'request_payload_size_bytes'
-        self.summary_metric_help = 'Request payload size in bytes.'
+        self.summary_metric_name = "request_payload_size_bytes"
+        self.summary_metric_help = "Request payload size in bytes."
         self.summary_metric_data = (
-            ({'route': '/'}, {0.5: 4.0, 0.9: 5.2, 0.99: 5.2, 'sum': 25.2, 'count': 4}),
+            ({"route": "/"}, {0.5: 4.0, 0.9: 5.2, 0.99: 5.2, "sum": 25.2, "count": 4}),
         )
-        self.summary_metric_data_values = (
-            ({'route': '/'}, (3, 5.2, 13, 4)),
-        )
+        self.summary_metric_data_values = (({"route": "/"}, (3, 5.2, 13, 4)),)
 
         # Histogram test fields
-        self.histogram_metric_name = 'request_latency_seconds'
-        self.histogram_metric_help = 'Request latency in seconds.'
+        self.histogram_metric_name = "request_latency_seconds"
+        self.histogram_metric_help = "Request latency in seconds."
         self.histogram_metric_buckets = [5.0, 10.0, 15.0]
         # buckets typically have a POS_INF upper bound to catch values
         # beyond the largest bucket bound. Simulate this behavior.
         POS_INF = float("inf")
         self.histogram_metric_data = (
-            ({'route': '/'}, {5.0: 2, 10.0: 1, 15.0: 1, POS_INF: 0, 'sum': 25.2, 'count': 4}),
+            (
+                {"route": "/"},
+                {5.0: 2, 10.0: 1, 15.0: 1, POS_INF: 0, "sum": 25.2, "count": 4},
+            ),
         )
-        self.histogram_metric_data_values = (
-            ({'route': '/'}, (3, 5.2, 13, 4)),
-        )
+        self.histogram_metric_data_values = (({"route": "/"}, (3, 5.2, 13, 4)),)
 
     def test_headers_binary(self):
-        ''' check binary header info is provided '''
+        """ check binary header info is provided """
         f = BinaryFormatter()
-        expected_result = {'Content-Type': BINARY_CONTENT_TYPE}
+        expected_result = {"Content-Type": BINARY_CONTENT_TYPE}
         self.assertEqual(expected_result, f.get_headers())
 
     def test_no_metric_instances_present_binary(self):
-        ''' Check marshalling a collector with no metrics instances present '''
+        """ Check marshalling a collector with no metrics instances present """
 
-        c = Counter(name=self.counter_metric_name,
-                    doc=self.counter_metric_help,
-                    const_labels=self.const_labels)
+        c = Counter(
+            name=self.counter_metric_name,
+            doc=self.counter_metric_help,
+            const_labels=self.const_labels,
+        )
 
         f = BinaryFormatter()
 
@@ -84,17 +84,15 @@ class TestProtobufFormat(unittest.TestCase):
         # Construct the result expected to receive when the counter
         # collector is marshalled.
         expected_result = pmp.create_counter(
-            self.counter_metric_name,
-            self.counter_metric_help,
-            [])
+            self.counter_metric_name, self.counter_metric_help, []
+        )
 
         self.assertEqual(result, expected_result)
 
     def test_counter_format_binary(self):
 
         # Check simple metric
-        c = Counter(name=self.counter_metric_name,
-                    doc=self.counter_metric_help)
+        c = Counter(name=self.counter_metric_name, doc=self.counter_metric_help)
 
         # Add data to the collector
         for labels, value in self.counter_metric_data:
@@ -108,18 +106,19 @@ class TestProtobufFormat(unittest.TestCase):
         # Construct the result expected to receive when the counter
         # collector is marshalled.
         expected_result = pmp.create_counter(
-            self.counter_metric_name,
-            self.counter_metric_help,
-            self.counter_metric_data)
+            self.counter_metric_name, self.counter_metric_help, self.counter_metric_data
+        )
 
         self.assertEqual(result, expected_result)
 
         ######################################################################
 
         # Check metric with constant labels
-        c = Counter(name=self.counter_metric_name,
-                    doc=self.counter_metric_help,
-                    const_labels=self.const_labels)
+        c = Counter(
+            name=self.counter_metric_name,
+            doc=self.counter_metric_help,
+            const_labels=self.const_labels,
+        )
 
         # Add data to the collector
         for labels, value in self.counter_metric_data:
@@ -136,17 +135,19 @@ class TestProtobufFormat(unittest.TestCase):
             self.counter_metric_name,
             self.counter_metric_help,
             self.counter_metric_data,
-            const_labels=self.const_labels)
+            const_labels=self.const_labels,
+        )
 
         self.assertEqual(result, expected_result)
 
         ######################################################################
 
         # Check metric with timestamps
-        with unittest.mock.patch.object(pmp.utils, '_timestamp_ms', return_value=TEST_TIMESTAMP):
+        with unittest.mock.patch.object(
+            pmp.utils, "_timestamp_ms", return_value=TEST_TIMESTAMP
+        ):
 
-            c = Counter(name=self.counter_metric_name,
-                        doc=self.counter_metric_help)
+            c = Counter(name=self.counter_metric_name, doc=self.counter_metric_help)
 
             # Add data to the collector
             for labels, value in self.counter_metric_data:
@@ -163,14 +164,14 @@ class TestProtobufFormat(unittest.TestCase):
                 self.counter_metric_name,
                 self.counter_metric_help,
                 self.counter_metric_data,
-                timestamp=True)
+                timestamp=True,
+            )
 
             self.assertEqual(result, expected_result)
 
     def test_gauge_format_binary(self):
 
-        g = Gauge(name=self.gauge_metric_name,
-                  doc=self.gauge_metric_help)
+        g = Gauge(name=self.gauge_metric_name, doc=self.gauge_metric_help)
 
         # Add data to the collector
         for labels, values in self.gauge_metric_data:
@@ -184,18 +185,19 @@ class TestProtobufFormat(unittest.TestCase):
         # Construct the result to expected to receive when the gauge
         # collector is marshalled.
         expected_result = pmp.create_gauge(
-            self.gauge_metric_name,
-            self.gauge_metric_help,
-            self.gauge_metric_data)
+            self.gauge_metric_name, self.gauge_metric_help, self.gauge_metric_data
+        )
 
         self.assertEqual(result, expected_result)
 
         ######################################################################
 
         # Check metric with constant labels
-        g = Gauge(name=self.gauge_metric_name,
-                  doc=self.gauge_metric_help,
-                  const_labels=self.const_labels)
+        g = Gauge(
+            name=self.gauge_metric_name,
+            doc=self.gauge_metric_help,
+            const_labels=self.const_labels,
+        )
 
         # Add data to the collector
         for labels, values in self.gauge_metric_data:
@@ -212,17 +214,19 @@ class TestProtobufFormat(unittest.TestCase):
             self.gauge_metric_name,
             self.gauge_metric_help,
             self.gauge_metric_data,
-            const_labels=self.const_labels)
+            const_labels=self.const_labels,
+        )
 
         self.assertEqual(result, expected_result)
 
         ######################################################################
 
         # Check metric with timestamps
-        with unittest.mock.patch.object(pmp.utils, '_timestamp_ms', return_value=TEST_TIMESTAMP):
+        with unittest.mock.patch.object(
+            pmp.utils, "_timestamp_ms", return_value=TEST_TIMESTAMP
+        ):
 
-            g = Gauge(name=self.gauge_metric_name,
-                      doc=self.gauge_metric_help)
+            g = Gauge(name=self.gauge_metric_name, doc=self.gauge_metric_help)
 
             # Add data to the collector
             for labels, values in self.gauge_metric_data:
@@ -239,14 +243,14 @@ class TestProtobufFormat(unittest.TestCase):
                 self.gauge_metric_name,
                 self.gauge_metric_help,
                 self.gauge_metric_data,
-                timestamp=True)
+                timestamp=True,
+            )
 
             self.assertEqual(result, expected_result)
 
     def test_summary_format_binary(self):
 
-        s = Summary(name=self.summary_metric_name,
-                    doc=self.summary_metric_help)
+        s = Summary(name=self.summary_metric_name, doc=self.summary_metric_help)
 
         # Add data to the collector
         for labels, values in self.summary_metric_data_values:
@@ -262,18 +266,19 @@ class TestProtobufFormat(unittest.TestCase):
         # Construct the result to expected to receive when the summary
         # collector is marshalled.
         expected_result = pmp.create_summary(
-            self.summary_metric_name,
-            self.summary_metric_help,
-            self.summary_metric_data)
+            self.summary_metric_name, self.summary_metric_help, self.summary_metric_data
+        )
 
         self.assertEqual(result, expected_result)
 
         ######################################################################
 
         # Check metric with constant labels
-        s = Summary(name=self.summary_metric_name,
-                    doc=self.summary_metric_help,
-                    const_labels=self.const_labels)
+        s = Summary(
+            name=self.summary_metric_name,
+            doc=self.summary_metric_help,
+            const_labels=self.const_labels,
+        )
 
         # Add data to the collector
         for labels, values in self.summary_metric_data_values:
@@ -292,17 +297,19 @@ class TestProtobufFormat(unittest.TestCase):
             self.summary_metric_name,
             self.summary_metric_help,
             self.summary_metric_data,
-            const_labels=self.const_labels)
+            const_labels=self.const_labels,
+        )
 
         self.assertEqual(result, expected_result)
 
         ######################################################################
 
         # Check metric with timestamps
-        with unittest.mock.patch.object(pmp.utils, '_timestamp_ms', return_value=TEST_TIMESTAMP):
+        with unittest.mock.patch.object(
+            pmp.utils, "_timestamp_ms", return_value=TEST_TIMESTAMP
+        ):
 
-            s = Summary(name=self.summary_metric_name,
-                        doc=self.summary_metric_help)
+            s = Summary(name=self.summary_metric_name, doc=self.summary_metric_help)
 
             # Add data to the collector
             for labels, values in self.summary_metric_data_values:
@@ -321,7 +328,8 @@ class TestProtobufFormat(unittest.TestCase):
                 self.summary_metric_name,
                 self.summary_metric_help,
                 self.summary_metric_data,
-                timestamp=True)
+                timestamp=True,
+            )
 
         self.assertEqual(result, expected_result)
 
@@ -330,19 +338,33 @@ class TestProtobufFormat(unittest.TestCase):
         # Check metric with multiple metric instances
 
         input_summary_data = (
-            ({'interval': "5s"}, [3, 5.2, 13, 4]),
-            ({'interval': "10s"}, [1.3, 1.2, 32.1, 59.2, 109.46, 70.9]),
-            ({'interval': "10s", 'method': "fast"}, [5, 9.8, 31, 9.7, 101.4]),
+            ({"interval": "5s"}, [3, 5.2, 13, 4]),
+            ({"interval": "10s"}, [1.3, 1.2, 32.1, 59.2, 109.46, 70.9]),
+            ({"interval": "10s", "method": "fast"}, [5, 9.8, 31, 9.7, 101.4]),
         )
 
         managed_summary_data = (
-            ({'interval': "5s"}, {0.5: 4.0, 0.9: 5.2, 0.99: 5.2, "sum": 25.2, "count": 4}),
-            ({'interval': "10s"}, {0.5: 32.1, 0.9: 59.2, 0.99: 59.2, "sum": 274.15999999999997, "count": 6}),
-            ({'interval': "10s", 'method': "fast"}, {0.5: 9.7, 0.9: 9.8, 0.99: 9.8, "sum": 156.9, "count": 5}),
+            (
+                {"interval": "5s"},
+                {0.5: 4.0, 0.9: 5.2, 0.99: 5.2, "sum": 25.2, "count": 4},
+            ),
+            (
+                {"interval": "10s"},
+                {
+                    0.5: 32.1,
+                    0.9: 59.2,
+                    0.99: 59.2,
+                    "sum": 274.15999999999997,
+                    "count": 6,
+                },
+            ),
+            (
+                {"interval": "10s", "method": "fast"},
+                {0.5: 9.7, 0.9: 9.8, 0.99: 9.8, "sum": 156.9, "count": 5},
+            ),
         )
 
-        s = Summary(name=self.summary_metric_name,
-                    doc=self.summary_metric_help)
+        s = Summary(name=self.summary_metric_name, doc=self.summary_metric_help)
 
         # Add data to the collector
         for labels, values in input_summary_data:
@@ -358,45 +380,18 @@ class TestProtobufFormat(unittest.TestCase):
         # Construct the result to expected to receive when the summary
         # collector is marshalled.
         expected_result = pmp.create_summary(
-            self.summary_metric_name,
-            self.summary_metric_help,
-            managed_summary_data)
+            self.summary_metric_name, self.summary_metric_help, managed_summary_data
+        )
 
         self.assertEqual(result, expected_result)
 
     def test_histogram_format_binary(self):
 
-        h = Histogram(name=self.histogram_metric_name,
-                      doc=self.histogram_metric_help,
-                      buckets=self.histogram_metric_buckets)
-
-        # Add data to the collector
-        for labels, values in self.histogram_metric_data_values:
-            for value in values:
-                h.add(labels, value)
-
-        f = BinaryFormatter()
-
-        result = f.marshall_collector(h)
-        self.assertIsInstance(result, pmp.MetricFamily)
-        self.assertEqual(len(result.metric), 1)
-
-        # Construct the result to expected to receive when the histogram
-        # collector is marshalled.
-        expected_result = pmp.create_histogram(
-            self.histogram_metric_name,
-            self.histogram_metric_help,
-            self.histogram_metric_data)
-
-        self.assertEqual(result, expected_result)
-
-        ######################################################################
-
-        # Check metric with constant labels
-        h = Histogram(name=self.histogram_metric_name,
-                      doc=self.histogram_metric_help,
-                      const_labels=self.const_labels,
-                      buckets=self.histogram_metric_buckets)
+        h = Histogram(
+            name=self.histogram_metric_name,
+            doc=self.histogram_metric_help,
+            buckets=self.histogram_metric_buckets,
+        )
 
         # Add data to the collector
         for labels, values in self.histogram_metric_data_values:
@@ -415,18 +410,54 @@ class TestProtobufFormat(unittest.TestCase):
             self.histogram_metric_name,
             self.histogram_metric_help,
             self.histogram_metric_data,
-            const_labels=self.const_labels)
+        )
+
+        self.assertEqual(result, expected_result)
+
+        ######################################################################
+
+        # Check metric with constant labels
+        h = Histogram(
+            name=self.histogram_metric_name,
+            doc=self.histogram_metric_help,
+            const_labels=self.const_labels,
+            buckets=self.histogram_metric_buckets,
+        )
+
+        # Add data to the collector
+        for labels, values in self.histogram_metric_data_values:
+            for value in values:
+                h.add(labels, value)
+
+        f = BinaryFormatter()
+
+        result = f.marshall_collector(h)
+        self.assertIsInstance(result, pmp.MetricFamily)
+        self.assertEqual(len(result.metric), 1)
+
+        # Construct the result to expected to receive when the histogram
+        # collector is marshalled.
+        expected_result = pmp.create_histogram(
+            self.histogram_metric_name,
+            self.histogram_metric_help,
+            self.histogram_metric_data,
+            const_labels=self.const_labels,
+        )
 
         self.assertEqual(result, expected_result)
 
         ######################################################################
 
         # Check metric with timestamps
-        with unittest.mock.patch.object(pmp.utils, '_timestamp_ms', return_value=TEST_TIMESTAMP):
+        with unittest.mock.patch.object(
+            pmp.utils, "_timestamp_ms", return_value=TEST_TIMESTAMP
+        ):
 
-            h = Histogram(name=self.histogram_metric_name,
-                          doc=self.histogram_metric_help,
-                          buckets=self.histogram_metric_buckets)
+            h = Histogram(
+                name=self.histogram_metric_name,
+                doc=self.histogram_metric_help,
+                buckets=self.histogram_metric_buckets,
+            )
 
             # Add data to the collector
             for labels, values in self.histogram_metric_data_values:
@@ -445,20 +476,18 @@ class TestProtobufFormat(unittest.TestCase):
                 self.histogram_metric_name,
                 self.histogram_metric_help,
                 self.histogram_metric_data,
-                timestamp=True)
+                timestamp=True,
+            )
 
         self.assertEqual(result, expected_result)
 
     def test_registry_marshall_counter(self):
 
-        counter_data = (
-            ({'c_sample': '1', 'c_subsample': 'b'}, 400),
-        )
+        counter_data = (({"c_sample": "1", "c_subsample": "b"}, 400),)
 
         counter = Counter(
-            "counter_test",
-            "A counter.",
-            const_labels={'type': "counter"})
+            "counter_test", "A counter.", const_labels={"type": "counter"}
+        )
 
         for labels, value in counter_data:
             counter.set(labels, value)
@@ -466,24 +495,21 @@ class TestProtobufFormat(unittest.TestCase):
         registry = Registry()
         registry.register(counter)
 
-        valid_result = (b'[\n\x0ccounter_test\x12\nA counter.\x18\x00"=\n\r'
-                        b'\n\x08c_sample\x12\x011\n\x10\n\x0bc_subsample\x12'
-                        b'\x01b\n\x0f\n\x04type\x12\x07counter\x1a\t\t\x00\x00'
-                        b'\x00\x00\x00\x00y@')
+        valid_result = (
+            b'[\n\x0ccounter_test\x12\nA counter.\x18\x00"=\n\r'
+            b"\n\x08c_sample\x12\x011\n\x10\n\x0bc_subsample\x12"
+            b"\x01b\n\x0f\n\x04type\x12\x07counter\x1a\t\t\x00\x00"
+            b"\x00\x00\x00\x00y@"
+        )
         f = BinaryFormatter()
 
         self.assertEqual(valid_result, f.marshall(registry))
 
     def test_registry_marshall_gauge(self):
 
-        gauge_data = (
-            ({'g_sample': '1', 'g_subsample': 'b'}, 800),
-        )
+        gauge_data = (({"g_sample": "1", "g_subsample": "b"}, 800),)
 
-        gauge = Gauge(
-            "gauge_test",
-            "A gauge.",
-            const_labels={'type': "gauge"})
+        gauge = Gauge("gauge_test", "A gauge.", const_labels={"type": "gauge"})
 
         for labels, value in gauge_data:
             gauge.set(labels, value)
@@ -491,10 +517,12 @@ class TestProtobufFormat(unittest.TestCase):
         registry = Registry()
         registry.register(gauge)
 
-        valid_result = (b'U\n\ngauge_test\x12\x08A gauge.\x18\x01";'
-                        b'\n\r\n\x08g_sample\x12\x011\n\x10\n\x0bg_subsample'
-                        b'\x12\x01b\n\r\n\x04type\x12\x05gauge\x12\t\t\x00'
-                        b'\x00\x00\x00\x00\x00\x89@')
+        valid_result = (
+            b'U\n\ngauge_test\x12\x08A gauge.\x18\x01";'
+            b"\n\r\n\x08g_sample\x12\x011\n\x10\n\x0bg_subsample"
+            b"\x12\x01b\n\r\n\x04type\x12\x05gauge\x12\t\t\x00"
+            b"\x00\x00\x00\x00\x00\x89@"
+        )
 
         f = BinaryFormatter()
 
@@ -509,14 +537,9 @@ class TestProtobufFormat(unittest.TestCase):
         #      {0.5: 4235.0, 0.9: 4470.0, 0.99: 4517.0, 'count': 22, 'sum': 98857.0}),
         # )
 
-        summary_data = (
-            ({'s_sample': '1', 's_subsample': 'b'}, range(4000, 5000, 47)),
-        )
+        summary_data = (({"s_sample": "1", "s_subsample": "b"}, range(4000, 5000, 47)),)
 
-        summary = Summary(
-            metric_name,
-            metric_help,
-            const_labels={'type': "summary"})
+        summary = Summary(metric_name, metric_help, const_labels={"type": "summary"})
 
         for labels, values in summary_data:
             for v in values:
@@ -525,38 +548,44 @@ class TestProtobufFormat(unittest.TestCase):
         registry = Registry()
         registry.register(summary)
 
-        valid_result = (b'\x99\x01\n\x0csummary_test\x12\nA summary.'
-                        b'\x18\x02"{\n\r\n\x08s_sample\x12\x011\n\x10\n'
-                        b'\x0bs_subsample\x12\x01b\n\x0f\n\x04type\x12\x07'
-                        b'summary"G\x08\x16\x11\x00\x00\x00\x00\x90"\xf8@'
-                        b'\x1a\x12\t\x00\x00\x00\x00\x00\x00\xe0?\x11\x00'
-                        b'\x00\x00\x00\x00\x8b\xb0@\x1a\x12\t\xcd\xcc\xcc'
-                        b'\xcc\xcc\xcc\xec?\x11\x00\x00\x00\x00\x00v\xb1@'
-                        b'\x1a\x12\t\xaeG\xe1z\x14\xae\xef?\x11\x00\x00\x00'
-                        b'\x00\x00\xa5\xb1@')
+        valid_result = (
+            b"\x99\x01\n\x0csummary_test\x12\nA summary."
+            b'\x18\x02"{\n\r\n\x08s_sample\x12\x011\n\x10\n'
+            b"\x0bs_subsample\x12\x01b\n\x0f\n\x04type\x12\x07"
+            b'summary"G\x08\x16\x11\x00\x00\x00\x00\x90"\xf8@'
+            b"\x1a\x12\t\x00\x00\x00\x00\x00\x00\xe0?\x11\x00"
+            b"\x00\x00\x00\x00\x8b\xb0@\x1a\x12\t\xcd\xcc\xcc"
+            b"\xcc\xcc\xcc\xec?\x11\x00\x00\x00\x00\x00v\xb1@"
+            b"\x1a\x12\t\xaeG\xe1z\x14\xae\xef?\x11\x00\x00\x00"
+            b"\x00\x00\xa5\xb1@"
+        )
 
         f = BinaryFormatter()
 
         self.assertEqual(valid_result, f.marshall(registry))
 
     def test_registry_marshall_histogram(self):
-        ''' check encode of histogram matches expected output '''
+        """ check encode of histogram matches expected output """
 
         metric_name = "histogram_test"
         metric_help = "A histogram."
         metric_data = (
-            ({'h_sample': '1', 'h_subsample': 'b'},
-             {5.0: 3, 10.0: 2, 15.0: 1, 'count': 6, 'sum': 46.0}),
+            (
+                {"h_sample": "1", "h_subsample": "b"},
+                {5.0: 3, 10.0: 2, 15.0: 1, "count": 6, "sum": 46.0},
+            ),
         )
         histogram_data = (
-            ({'h_sample': '1', 'h_subsample': 'b'}, (4.5, 5.0, 4.0, 9.6, 9.0, 13.9)),
+            ({"h_sample": "1", "h_subsample": "b"}, (4.5, 5.0, 4.0, 9.6, 9.0, 13.9)),
         )
 
         POS_INF = float("inf")
         histogram = Histogram(
-            metric_name, metric_help,
-            const_labels={'type': "histogram"},
-            buckets=(5.0, 10.0, 15.0, POS_INF))
+            metric_name,
+            metric_help,
+            const_labels={"type": "histogram"},
+            buckets=(5.0, 10.0, 15.0, POS_INF),
+        )
         for labels, values in histogram_data:
             for v in values:
                 histogram.add(labels, v)
@@ -564,14 +593,16 @@ class TestProtobufFormat(unittest.TestCase):
         registry = Registry()
         registry.register(histogram)
 
-        valid_result = (b'\x97\x01\n\x0ehistogram_test\x12\x0cA histogram.'
-                        b'\x18\x04"u\n\r\n\x08h_sample\x12\x011\n\x10\n'
-                        b'\x0bh_subsample\x12\x01b\n\x11\n\x04type\x12\t'
-                        b'histogram:?\x08\x06\x11\x00\x00\x00\x00\x00\x00G@'
-                        b'\x1a\x0b\x08\x03\x11\x00\x00\x00\x00\x00\x00\x14@'
-                        b'\x1a\x0b\x08\x02\x11\x00\x00\x00\x00\x00\x00$@\x1a'
-                        b'\x0b\x08\x01\x11\x00\x00\x00\x00\x00\x00.@\x1a\x0b'
-                        b'\x08\x00\x11\x00\x00\x00\x00\x00\x00\xf0\x7f')
+        valid_result = (
+            b"\x97\x01\n\x0ehistogram_test\x12\x0cA histogram."
+            b'\x18\x04"u\n\r\n\x08h_sample\x12\x011\n\x10\n'
+            b"\x0bh_subsample\x12\x01b\n\x11\n\x04type\x12\t"
+            b"histogram:?\x08\x06\x11\x00\x00\x00\x00\x00\x00G@"
+            b"\x1a\x0b\x08\x03\x11\x00\x00\x00\x00\x00\x00\x14@"
+            b"\x1a\x0b\x08\x02\x11\x00\x00\x00\x00\x00\x00$@\x1a"
+            b"\x0b\x08\x01\x11\x00\x00\x00\x00\x00\x00.@\x1a\x0b"
+            b"\x08\x00\x11\x00\x00\x00\x00\x00\x00\xf0\x7f"
+        )
 
         f = BinaryFormatter()
 

--- a/tests/test_formats_text.py
+++ b/tests/test_formats_text.py
@@ -1,8 +1,7 @@
 import re
 import unittest
 
-from aioprometheus import (
-    Collector, Counter, Gauge, Histogram, Summary, Registry)
+from aioprometheus import Collector, Counter, Gauge, Histogram, Summary, Registry
 from aioprometheus.formats import TextFormatter, TEXT_CONTENT_TYPE
 
 
@@ -10,14 +9,14 @@ class TestTextFormat(unittest.TestCase):
 
     def test_headers(self):
         f = TextFormatter()
-        expected_result = {'Content-Type': TEXT_CONTENT_TYPE}
+        expected_result = {"Content-Type": TEXT_CONTENT_TYPE}
         self.assertEqual(expected_result, f.get_headers())
 
     def test_wrong_format(self):
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {"app": "my_app"},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {"app": "my_app"},
         }
 
         f = TextFormatter()
@@ -27,47 +26,47 @@ class TestTextFormat(unittest.TestCase):
         with self.assertRaises(TypeError) as context:
             f.marshall_collector(c)
 
-        self.assertEqual('Not a valid object format', str(context.exception))
+        self.assertEqual("Not a valid object format", str(context.exception))
 
     def test_counter_format(self):
 
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': None,
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": None,
         }
         c = Counter(**self.data)
 
         counter_data = (
-            ({'country': "sp", "device": "desktop"}, 520),
-            ({'country': "us", "device": "mobile"}, 654),
-            ({'country': "uk", "device": "desktop"}, 1001),
-            ({'country': "de", "device": "desktop"}, 995),
-            ({'country': "zh", "device": "desktop"}, 520),
-            ({'country': "ch", "device": "mobile"}, 654),
-            ({'country': "ca", "device": "desktop"}, 1001),
-            ({'country': "jp", "device": "desktop"}, 995),
-            ({'country': "au", "device": "desktop"}, 520),
-            ({'country': "py", "device": "mobile"}, 654),
-            ({'country': "ar", "device": "desktop"}, 1001),
-            ({'country': "pt", "device": "desktop"}, 995),
+            ({"country": "sp", "device": "desktop"}, 520),
+            ({"country": "us", "device": "mobile"}, 654),
+            ({"country": "uk", "device": "desktop"}, 1001),
+            ({"country": "de", "device": "desktop"}, 995),
+            ({"country": "zh", "device": "desktop"}, 520),
+            ({"country": "ch", "device": "mobile"}, 654),
+            ({"country": "ca", "device": "desktop"}, 1001),
+            ({"country": "jp", "device": "desktop"}, 995),
+            ({"country": "au", "device": "desktop"}, 520),
+            ({"country": "py", "device": "mobile"}, 654),
+            ({"country": "ar", "device": "desktop"}, 1001),
+            ({"country": "pt", "device": "desktop"}, 995),
         )
 
         valid_result = (
             "# HELP logged_users_total Logged users in the application",
             "# TYPE logged_users_total counter",
-            "logged_users_total{country=\"ch\",device=\"mobile\"} 654",
-            "logged_users_total{country=\"zh\",device=\"desktop\"} 520",
-            "logged_users_total{country=\"jp\",device=\"desktop\"} 995",
-            "logged_users_total{country=\"de\",device=\"desktop\"} 995",
-            "logged_users_total{country=\"pt\",device=\"desktop\"} 995",
-            "logged_users_total{country=\"ca\",device=\"desktop\"} 1001",
-            "logged_users_total{country=\"sp\",device=\"desktop\"} 520",
-            "logged_users_total{country=\"au\",device=\"desktop\"} 520",
-            "logged_users_total{country=\"uk\",device=\"desktop\"} 1001",
-            "logged_users_total{country=\"py\",device=\"mobile\"} 654",
-            "logged_users_total{country=\"us\",device=\"mobile\"} 654",
-            "logged_users_total{country=\"ar\",device=\"desktop\"} 1001",
+            'logged_users_total{country="ch",device="mobile"} 654',
+            'logged_users_total{country="zh",device="desktop"} 520',
+            'logged_users_total{country="jp",device="desktop"} 995',
+            'logged_users_total{country="de",device="desktop"} 995',
+            'logged_users_total{country="pt",device="desktop"} 995',
+            'logged_users_total{country="ca",device="desktop"} 1001',
+            'logged_users_total{country="sp",device="desktop"} 520',
+            'logged_users_total{country="au",device="desktop"} 520',
+            'logged_users_total{country="uk",device="desktop"} 1001',
+            'logged_users_total{country="py",device="mobile"} 654',
+            'logged_users_total{country="us",device="mobile"} 654',
+            'logged_users_total{country="ar",device="desktop"} 1001',
         )
 
         # Add data to the collector
@@ -86,42 +85,42 @@ class TestTextFormat(unittest.TestCase):
     def test_counter_format_with_const_labels(self):
 
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {"app": "my_app"},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {"app": "my_app"},
         }
         c = Counter(**self.data)
 
         counter_data = (
-            ({'country': "sp", "device": "desktop"}, 520),
-            ({'country': "us", "device": "mobile"}, 654),
-            ({'country': "uk", "device": "desktop"}, 1001),
-            ({'country': "de", "device": "desktop"}, 995),
-            ({'country': "zh", "device": "desktop"}, 520),
-            ({'country': "ch", "device": "mobile"}, 654),
-            ({'country': "ca", "device": "desktop"}, 1001),
-            ({'country': "jp", "device": "desktop"}, 995),
-            ({'country': "au", "device": "desktop"}, 520),
-            ({'country': "py", "device": "mobile"}, 654),
-            ({'country': "ar", "device": "desktop"}, 1001),
-            ({'country': "pt", "device": "desktop"}, 995),
+            ({"country": "sp", "device": "desktop"}, 520),
+            ({"country": "us", "device": "mobile"}, 654),
+            ({"country": "uk", "device": "desktop"}, 1001),
+            ({"country": "de", "device": "desktop"}, 995),
+            ({"country": "zh", "device": "desktop"}, 520),
+            ({"country": "ch", "device": "mobile"}, 654),
+            ({"country": "ca", "device": "desktop"}, 1001),
+            ({"country": "jp", "device": "desktop"}, 995),
+            ({"country": "au", "device": "desktop"}, 520),
+            ({"country": "py", "device": "mobile"}, 654),
+            ({"country": "ar", "device": "desktop"}, 1001),
+            ({"country": "pt", "device": "desktop"}, 995),
         )
 
         valid_result = (
             "# HELP logged_users_total Logged users in the application",
             "# TYPE logged_users_total counter",
-            "logged_users_total{app=\"my_app\",country=\"ch\",device=\"mobile\"} 654",
-            "logged_users_total{app=\"my_app\",country=\"zh\",device=\"desktop\"} 520",
-            "logged_users_total{app=\"my_app\",country=\"jp\",device=\"desktop\"} 995",
-            "logged_users_total{app=\"my_app\",country=\"de\",device=\"desktop\"} 995",
-            "logged_users_total{app=\"my_app\",country=\"pt\",device=\"desktop\"} 995",
-            "logged_users_total{app=\"my_app\",country=\"ca\",device=\"desktop\"} 1001",
-            "logged_users_total{app=\"my_app\",country=\"sp\",device=\"desktop\"} 520",
-            "logged_users_total{app=\"my_app\",country=\"au\",device=\"desktop\"} 520",
-            "logged_users_total{app=\"my_app\",country=\"uk\",device=\"desktop\"} 1001",
-            "logged_users_total{app=\"my_app\",country=\"py\",device=\"mobile\"} 654",
-            "logged_users_total{app=\"my_app\",country=\"us\",device=\"mobile\"} 654",
-            "logged_users_total{app=\"my_app\",country=\"ar\",device=\"desktop\"} 1001",
+            'logged_users_total{app="my_app",country="ch",device="mobile"} 654',
+            'logged_users_total{app="my_app",country="zh",device="desktop"} 520',
+            'logged_users_total{app="my_app",country="jp",device="desktop"} 995',
+            'logged_users_total{app="my_app",country="de",device="desktop"} 995',
+            'logged_users_total{app="my_app",country="pt",device="desktop"} 995',
+            'logged_users_total{app="my_app",country="ca",device="desktop"} 1001',
+            'logged_users_total{app="my_app",country="sp",device="desktop"} 520',
+            'logged_users_total{app="my_app",country="au",device="desktop"} 520',
+            'logged_users_total{app="my_app",country="uk",device="desktop"} 1001',
+            'logged_users_total{app="my_app",country="py",device="mobile"} 654',
+            'logged_users_total{app="my_app",country="us",device="mobile"} 654',
+            'logged_users_total{app="my_app",country="ar",device="desktop"} 1001',
         )
 
         # Add data to the collector
@@ -154,14 +153,70 @@ container_cpu_usage_seconds_total{id="cefa0b389a634a0b2f3c2f52ade668d71de75e5775
 container_cpu_usage_seconds_total{id="cefa0b389a634a0b2f3c2f52ade668d71de75e5775e91297bd65bebe745ba054",name="prometheus",type="user"} 0"""
 
         data = (
-            ({'id': "110863b5395f7f3476d44e7cb8799f2643abbd385dd544bcc379538ac6ffc5ca", 'name': "container-extractor", 'type': "kernel"}, 0),
-            ({'id': "110863b5395f7f3476d44e7cb8799f2643abbd385dd544bcc379538ac6ffc5ca", 'name': "container-extractor", 'type': "user"}, 0),
-            ({'id': "7c1ae8f404be413a6413d0792123092446f694887f52ae6403356215943d3c36", 'name': "calendall_db_1", 'type': "kernel"}, 0),
-            ({'id': "7c1ae8f404be413a6413d0792123092446f694887f52ae6403356215943d3c36", 'name': "calendall_db_1", 'type': "user"}, 0),
-            ({'id': "c863b092d1ecdc68f54a6a4ed0d24fe629696be2337ccafb44c279c7c2d1c172", 'name': "calendall_web_run_8", 'type': "kernel"}, 0),
-            ({'id': "c863b092d1ecdc68f54a6a4ed0d24fe629696be2337ccafb44c279c7c2d1c172", 'name': "calendall_web_run_8", 'type': "user"}, 0),
-            ({'id': "cefa0b389a634a0b2f3c2f52ade668d71de75e5775e91297bd65bebe745ba054", 'name': "prometheus", 'type': "kernel"}, 0),
-            ({'id': "cefa0b389a634a0b2f3c2f52ade668d71de75e5775e91297bd65bebe745ba054", 'name': "prometheus", 'type': "user"}, 0),
+            (
+                {
+                    "id": "110863b5395f7f3476d44e7cb8799f2643abbd385dd544bcc379538ac6ffc5ca",
+                    "name": "container-extractor",
+                    "type": "kernel",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "110863b5395f7f3476d44e7cb8799f2643abbd385dd544bcc379538ac6ffc5ca",
+                    "name": "container-extractor",
+                    "type": "user",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "7c1ae8f404be413a6413d0792123092446f694887f52ae6403356215943d3c36",
+                    "name": "calendall_db_1",
+                    "type": "kernel",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "7c1ae8f404be413a6413d0792123092446f694887f52ae6403356215943d3c36",
+                    "name": "calendall_db_1",
+                    "type": "user",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "c863b092d1ecdc68f54a6a4ed0d24fe629696be2337ccafb44c279c7c2d1c172",
+                    "name": "calendall_web_run_8",
+                    "type": "kernel",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "c863b092d1ecdc68f54a6a4ed0d24fe629696be2337ccafb44c279c7c2d1c172",
+                    "name": "calendall_web_run_8",
+                    "type": "user",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "cefa0b389a634a0b2f3c2f52ade668d71de75e5775e91297bd65bebe745ba054",
+                    "name": "prometheus",
+                    "type": "kernel",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "cefa0b389a634a0b2f3c2f52ade668d71de75e5775e91297bd65bebe745ba054",
+                    "name": "prometheus",
+                    "type": "user",
+                },
+                0,
+            ),
         )
 
         # Create the counter
@@ -179,13 +234,13 @@ container_cpu_usage_seconds_total{id="cefa0b389a634a0b2f3c2f52ade668d71de75e5775
 
     def test_counter_format_with_timestamp(self):
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {},
         }
         c = Counter(**self.data)
 
-        counter_data = ({'country': "ch", "device": "mobile"}, 654)
+        counter_data = ({"country": "ch", "device": "mobile"}, 654)
 
         c.set_value(counter_data[0], counter_data[1])
 
@@ -207,9 +262,7 @@ logged_users_total{country="ch",device="mobile"} 654 \d*(?:.\d*)?$"""
 # TYPE prometheus_dns_sd_lookups_total counter
 prometheus_dns_sd_lookups_total 10"""
 
-        data = (
-            (None, 10),
-        )
+        data = ((None, 10),)
 
         # Create the counter
         c = Counter(name=name, doc=doc, const_labels={})
@@ -227,42 +280,42 @@ prometheus_dns_sd_lookups_total 10"""
     def test_gauge_format(self):
 
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {},
         }
         g = Gauge(**self.data)
 
         counter_data = (
-            ({'country': "sp", "device": "desktop"}, 520),
-            ({'country': "us", "device": "mobile"}, 654),
-            ({'country': "uk", "device": "desktop"}, 1001),
-            ({'country': "de", "device": "desktop"}, 995),
-            ({'country': "zh", "device": "desktop"}, 520),
-            ({'country': "ch", "device": "mobile"}, 654),
-            ({'country': "ca", "device": "desktop"}, 1001),
-            ({'country': "jp", "device": "desktop"}, 995),
-            ({'country': "au", "device": "desktop"}, 520),
-            ({'country': "py", "device": "mobile"}, 654),
-            ({'country': "ar", "device": "desktop"}, 1001),
-            ({'country': "pt", "device": "desktop"}, 995),
+            ({"country": "sp", "device": "desktop"}, 520),
+            ({"country": "us", "device": "mobile"}, 654),
+            ({"country": "uk", "device": "desktop"}, 1001),
+            ({"country": "de", "device": "desktop"}, 995),
+            ({"country": "zh", "device": "desktop"}, 520),
+            ({"country": "ch", "device": "mobile"}, 654),
+            ({"country": "ca", "device": "desktop"}, 1001),
+            ({"country": "jp", "device": "desktop"}, 995),
+            ({"country": "au", "device": "desktop"}, 520),
+            ({"country": "py", "device": "mobile"}, 654),
+            ({"country": "ar", "device": "desktop"}, 1001),
+            ({"country": "pt", "device": "desktop"}, 995),
         )
 
         valid_result = (
             "# HELP logged_users_total Logged users in the application",
             "# TYPE logged_users_total gauge",
-            "logged_users_total{country=\"ch\",device=\"mobile\"} 654",
-            "logged_users_total{country=\"zh\",device=\"desktop\"} 520",
-            "logged_users_total{country=\"jp\",device=\"desktop\"} 995",
-            "logged_users_total{country=\"de\",device=\"desktop\"} 995",
-            "logged_users_total{country=\"pt\",device=\"desktop\"} 995",
-            "logged_users_total{country=\"ca\",device=\"desktop\"} 1001",
-            "logged_users_total{country=\"sp\",device=\"desktop\"} 520",
-            "logged_users_total{country=\"au\",device=\"desktop\"} 520",
-            "logged_users_total{country=\"uk\",device=\"desktop\"} 1001",
-            "logged_users_total{country=\"py\",device=\"mobile\"} 654",
-            "logged_users_total{country=\"us\",device=\"mobile\"} 654",
-            "logged_users_total{country=\"ar\",device=\"desktop\"} 1001",
+            'logged_users_total{country="ch",device="mobile"} 654',
+            'logged_users_total{country="zh",device="desktop"} 520',
+            'logged_users_total{country="jp",device="desktop"} 995',
+            'logged_users_total{country="de",device="desktop"} 995',
+            'logged_users_total{country="pt",device="desktop"} 995',
+            'logged_users_total{country="ca",device="desktop"} 1001',
+            'logged_users_total{country="sp",device="desktop"} 520',
+            'logged_users_total{country="au",device="desktop"} 520',
+            'logged_users_total{country="uk",device="desktop"} 1001',
+            'logged_users_total{country="py",device="mobile"} 654',
+            'logged_users_total{country="us",device="mobile"} 654',
+            'logged_users_total{country="ar",device="desktop"} 1001',
         )
 
         # Add data to the collector
@@ -281,42 +334,42 @@ prometheus_dns_sd_lookups_total 10"""
     def test_gauge_format_with_const_labels(self):
 
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {"app": "my_app"},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {"app": "my_app"},
         }
         g = Gauge(**self.data)
 
         counter_data = (
-            ({'country': "sp", "device": "desktop"}, 520),
-            ({'country': "us", "device": "mobile"}, 654),
-            ({'country': "uk", "device": "desktop"}, 1001),
-            ({'country': "de", "device": "desktop"}, 995),
-            ({'country': "zh", "device": "desktop"}, 520),
-            ({'country': "ch", "device": "mobile"}, 654),
-            ({'country': "ca", "device": "desktop"}, 1001),
-            ({'country': "jp", "device": "desktop"}, 995),
-            ({'country': "au", "device": "desktop"}, 520),
-            ({'country': "py", "device": "mobile"}, 654),
-            ({'country': "ar", "device": "desktop"}, 1001),
-            ({'country': "pt", "device": "desktop"}, 995),
+            ({"country": "sp", "device": "desktop"}, 520),
+            ({"country": "us", "device": "mobile"}, 654),
+            ({"country": "uk", "device": "desktop"}, 1001),
+            ({"country": "de", "device": "desktop"}, 995),
+            ({"country": "zh", "device": "desktop"}, 520),
+            ({"country": "ch", "device": "mobile"}, 654),
+            ({"country": "ca", "device": "desktop"}, 1001),
+            ({"country": "jp", "device": "desktop"}, 995),
+            ({"country": "au", "device": "desktop"}, 520),
+            ({"country": "py", "device": "mobile"}, 654),
+            ({"country": "ar", "device": "desktop"}, 1001),
+            ({"country": "pt", "device": "desktop"}, 995),
         )
 
         valid_result = (
             "# HELP logged_users_total Logged users in the application",
             "# TYPE logged_users_total gauge",
-            "logged_users_total{app=\"my_app\",country=\"ch\",device=\"mobile\"} 654",
-            "logged_users_total{app=\"my_app\",country=\"zh\",device=\"desktop\"} 520",
-            "logged_users_total{app=\"my_app\",country=\"jp\",device=\"desktop\"} 995",
-            "logged_users_total{app=\"my_app\",country=\"de\",device=\"desktop\"} 995",
-            "logged_users_total{app=\"my_app\",country=\"pt\",device=\"desktop\"} 995",
-            "logged_users_total{app=\"my_app\",country=\"ca\",device=\"desktop\"} 1001",
-            "logged_users_total{app=\"my_app\",country=\"sp\",device=\"desktop\"} 520",
-            "logged_users_total{app=\"my_app\",country=\"au\",device=\"desktop\"} 520",
-            "logged_users_total{app=\"my_app\",country=\"uk\",device=\"desktop\"} 1001",
-            "logged_users_total{app=\"my_app\",country=\"py\",device=\"mobile\"} 654",
-            "logged_users_total{app=\"my_app\",country=\"us\",device=\"mobile\"} 654",
-            "logged_users_total{app=\"my_app\",country=\"ar\",device=\"desktop\"} 1001",
+            'logged_users_total{app="my_app",country="ch",device="mobile"} 654',
+            'logged_users_total{app="my_app",country="zh",device="desktop"} 520',
+            'logged_users_total{app="my_app",country="jp",device="desktop"} 995',
+            'logged_users_total{app="my_app",country="de",device="desktop"} 995',
+            'logged_users_total{app="my_app",country="pt",device="desktop"} 995',
+            'logged_users_total{app="my_app",country="ca",device="desktop"} 1001',
+            'logged_users_total{app="my_app",country="sp",device="desktop"} 520',
+            'logged_users_total{app="my_app",country="au",device="desktop"} 520',
+            'logged_users_total{app="my_app",country="uk",device="desktop"} 1001',
+            'logged_users_total{app="my_app",country="py",device="mobile"} 654',
+            'logged_users_total{app="my_app",country="us",device="mobile"} 654',
+            'logged_users_total{app="my_app",country="ar",device="desktop"} 1001',
         )
 
         # Add data to the collector
@@ -347,12 +400,48 @@ container_memory_max_usage_bytes{id="f30d1caaa142b1688a0684ed744fcae6d202a368776
 container_memory_max_usage_bytes{id="f835d921ffaf332f8d88ef5231ba149e389a2f37276f081878d6f982ef89a981",name="cocky_fermat"} 0"""
 
         data = (
-            ({'id': "4f70875bb57986783064fe958f694c9e225643b0d18e9cde6bdee56d47b7ce76", 'name': "prometheus"}, 0),
-            ({'id': "89042838f24f0ec0aa2a6c93ff44fd3f3e43057d35cfd32de89558112ecb92a0", 'name': "calendall_web_run_3"}, 0),
-            ({'id': "d11c6bc95459822e995fac4d4ae527f6cac442a1896a771dbb307ba276beceb9", 'name': "db"}, 0),
-            ({'id': "e4260cc9dca3e4e50ad2bffb0ec7432442197f135023ab629fe3576485cc65dd", 'name': "container-extractor"}, 0),
-            ({'id': "f30d1caaa142b1688a0684ed744fcae6d202a36877617b985e20a5d33801b311", 'name': "calendall_db_1"}, 0),
-            ({'id': "f835d921ffaf332f8d88ef5231ba149e389a2f37276f081878d6f982ef89a981", 'name': "cocky_fermat"}, 0),
+            (
+                {
+                    "id": "4f70875bb57986783064fe958f694c9e225643b0d18e9cde6bdee56d47b7ce76",
+                    "name": "prometheus",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "89042838f24f0ec0aa2a6c93ff44fd3f3e43057d35cfd32de89558112ecb92a0",
+                    "name": "calendall_web_run_3",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "d11c6bc95459822e995fac4d4ae527f6cac442a1896a771dbb307ba276beceb9",
+                    "name": "db",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "e4260cc9dca3e4e50ad2bffb0ec7432442197f135023ab629fe3576485cc65dd",
+                    "name": "container-extractor",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "f30d1caaa142b1688a0684ed744fcae6d202a36877617b985e20a5d33801b311",
+                    "name": "calendall_db_1",
+                },
+                0,
+            ),
+            (
+                {
+                    "id": "f835d921ffaf332f8d88ef5231ba149e389a2f37276f081878d6f982ef89a981",
+                    "name": "cocky_fermat",
+                },
+                0,
+            ),
         )
 
         # Create the counter
@@ -370,13 +459,13 @@ container_memory_max_usage_bytes{id="f835d921ffaf332f8d88ef5231ba149e389a2f37276
 
     def test_gauge_format_with_timestamp(self):
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {},
         }
         g = Gauge(**self.data)
 
-        counter_data = ({'country': "ch", "device": "mobile"}, 654)
+        counter_data = ({"country": "ch", "device": "mobile"}, 654)
 
         g.set_value(counter_data[0], counter_data[1])
 
@@ -398,9 +487,7 @@ logged_users_total{country="ch",device="mobile"} 654 \d*(?:.\d*)?$"""
 # TYPE prometheus_local_storage_indexing_queue_capacity gauge
 prometheus_local_storage_indexing_queue_capacity 16384"""
 
-        data = (
-            (None, 16384),
-        )
+        data = ((None, 16384),)
 
         # Create the counter
         g = Gauge(name=name, doc=doc, const_labels={})
@@ -417,22 +504,22 @@ prometheus_local_storage_indexing_queue_capacity 16384"""
 
     def test_one_summary_format(self):
         data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {},
         }
 
-        labels = {'handler': '/static'}
+        labels = {"handler": "/static"}
         values = [3, 5.2, 13, 4]
 
         valid_result = (
             "# HELP logged_users_total Logged users in the application",
             "# TYPE logged_users_total summary",
-            "logged_users_total{handler=\"/static\",quantile=\"0.5\"} 4.0",
-            "logged_users_total{handler=\"/static\",quantile=\"0.9\"} 5.2",
-            "logged_users_total{handler=\"/static\",quantile=\"0.99\"} 5.2",
-            "logged_users_total_count{handler=\"/static\"} 4",
-            "logged_users_total_sum{handler=\"/static\"} 25.2",
+            'logged_users_total{handler="/static",quantile="0.5"} 4.0',
+            'logged_users_total{handler="/static",quantile="0.9"} 5.2',
+            'logged_users_total{handler="/static",quantile="0.99"} 5.2',
+            'logged_users_total_count{handler="/static"} 4',
+            'logged_users_total_sum{handler="/static"} 25.2',
         )
 
         s = Summary(**data)
@@ -450,12 +537,12 @@ prometheus_local_storage_indexing_queue_capacity 16384"""
 
     def test_summary_format_text(self):
         data = {
-            'name': "prometheus_target_interval_length_seconds",
-            'doc': "Actual intervals between scrapes.",
-            'const_labels': {},
+            "name": "prometheus_target_interval_length_seconds",
+            "doc": "Actual intervals between scrapes.",
+            "const_labels": {},
         }
 
-        labels = {'interval': '5s'}
+        labels = {"interval": "5s"}
         values = [3, 5.2, 13, 4]
 
         valid_result = """# HELP prometheus_target_interval_length_seconds Actual intervals between scrapes.
@@ -478,35 +565,35 @@ prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2"""
 
     def test_multiple_summary_format(self):
         data = {
-            'name': "prometheus_target_interval_length_seconds",
-            'doc': "Actual intervals between scrapes.",
-            'const_labels': {},
+            "name": "prometheus_target_interval_length_seconds",
+            "doc": "Actual intervals between scrapes.",
+            "const_labels": {},
         }
 
         summary_data = (
-            ({'interval': "5s"}, [3, 5.2, 13, 4]),
-            ({'interval': "10s"}, [1.3, 1.2, 32.1, 59.2, 109.46, 70.9]),
-            ({'interval': "10s", 'method': "fast"}, [5, 9.8, 31, 9.7, 101.4]),
+            ({"interval": "5s"}, [3, 5.2, 13, 4]),
+            ({"interval": "10s"}, [1.3, 1.2, 32.1, 59.2, 109.46, 70.9]),
+            ({"interval": "10s", "method": "fast"}, [5, 9.8, 31, 9.7, 101.4]),
         )
 
         valid_result = (
             "# HELP prometheus_target_interval_length_seconds Actual intervals between scrapes.",
             "# TYPE prometheus_target_interval_length_seconds summary",
-            "prometheus_target_interval_length_seconds{interval=\"5s\",quantile=\"0.5\"} 4.0",
-            "prometheus_target_interval_length_seconds{interval=\"5s\",quantile=\"0.9\"} 5.2",
-            "prometheus_target_interval_length_seconds{interval=\"5s\",quantile=\"0.99\"} 5.2",
-            "prometheus_target_interval_length_seconds_count{interval=\"5s\"} 4",
-            "prometheus_target_interval_length_seconds_sum{interval=\"5s\"} 25.2",
-            "prometheus_target_interval_length_seconds{interval=\"10s\",quantile=\"0.5\"} 32.1",
-            "prometheus_target_interval_length_seconds{interval=\"10s\",quantile=\"0.9\"} 59.2",
-            "prometheus_target_interval_length_seconds{interval=\"10s\",quantile=\"0.99\"} 59.2",
-            "prometheus_target_interval_length_seconds_count{interval=\"10s\"} 6",
-            "prometheus_target_interval_length_seconds_sum{interval=\"10s\"} 274.15999999999997",
-            "prometheus_target_interval_length_seconds{interval=\"10s\",method=\"fast\",quantile=\"0.5\"} 9.7",
-            "prometheus_target_interval_length_seconds{interval=\"10s\",method=\"fast\",quantile=\"0.9\"} 9.8",
-            "prometheus_target_interval_length_seconds{interval=\"10s\",method=\"fast\",quantile=\"0.99\"} 9.8",
-            "prometheus_target_interval_length_seconds_count{interval=\"10s\",method=\"fast\"} 5",
-            "prometheus_target_interval_length_seconds_sum{interval=\"10s\",method=\"fast\"} 156.9",
+            'prometheus_target_interval_length_seconds{interval="5s",quantile="0.5"} 4.0',
+            'prometheus_target_interval_length_seconds{interval="5s",quantile="0.9"} 5.2',
+            'prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2',
+            'prometheus_target_interval_length_seconds_count{interval="5s"} 4',
+            'prometheus_target_interval_length_seconds_sum{interval="5s"} 25.2',
+            'prometheus_target_interval_length_seconds{interval="10s",quantile="0.5"} 32.1',
+            'prometheus_target_interval_length_seconds{interval="10s",quantile="0.9"} 59.2',
+            'prometheus_target_interval_length_seconds{interval="10s",quantile="0.99"} 59.2',
+            'prometheus_target_interval_length_seconds_count{interval="10s"} 6',
+            'prometheus_target_interval_length_seconds_sum{interval="10s"} 274.15999999999997',
+            'prometheus_target_interval_length_seconds{interval="10s",method="fast",quantile="0.5"} 9.7',
+            'prometheus_target_interval_length_seconds{interval="10s",method="fast",quantile="0.9"} 9.8',
+            'prometheus_target_interval_length_seconds{interval="10s",method="fast",quantile="0.99"} 9.8',
+            'prometheus_target_interval_length_seconds_count{interval="10s",method="fast"} 5',
+            'prometheus_target_interval_length_seconds_sum{interval="10s",method="fast"} 156.9',
         )
 
         s = Summary(**data)
@@ -522,9 +609,9 @@ prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2"""
 
     def test_single_summary_format(self):
         data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {},
         }
 
         labels = {}  # This one hasn't got labels
@@ -533,9 +620,9 @@ prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2"""
         valid_result = (
             "# HELP logged_users_total Logged users in the application",
             "# TYPE logged_users_total summary",
-            "logged_users_total{quantile=\"0.5\"} 4.0",
-            "logged_users_total{quantile=\"0.9\"} 5.2",
-            "logged_users_total{quantile=\"0.99\"} 5.2",
+            'logged_users_total{quantile="0.5"} 4.0',
+            'logged_users_total{quantile="0.9"} 5.2',
+            'logged_users_total{quantile="0.99"} 5.2',
             "logged_users_total_count 4",
             "logged_users_total_sum 25.2",
         )
@@ -555,12 +642,12 @@ prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2"""
 
     def test_summary_format_timestamp(self):
         data = {
-            'name': "prometheus_target_interval_length_seconds",
-            'doc': "Actual intervals between scrapes.",
-            'const_labels': {},
+            "name": "prometheus_target_interval_length_seconds",
+            "doc": "Actual intervals between scrapes.",
+            "const_labels": {},
         }
 
-        labels = {'interval': '5s'}
+        labels = {"interval": "5s"}
         values = [3, 5.2, 13, 4]
 
         result_regex = r"""# HELP prometheus_target_interval_length_seconds Actual intervals between scrapes.
@@ -586,30 +673,30 @@ prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2 \d*
         format_times = 10
 
         counter_data = (
-            ({'c_sample': '1'}, 100),
-            ({'c_sample': '2'}, 200),
-            ({'c_sample': '3'}, 300),
-            ({'c_sample': '1', 'c_subsample': 'b'}, 400),
+            ({"c_sample": "1"}, 100),
+            ({"c_sample": "2"}, 200),
+            ({"c_sample": "3"}, 300),
+            ({"c_sample": "1", "c_subsample": "b"}, 400),
         )
 
         gauge_data = (
-            ({'g_sample': '1'}, 500),
-            ({'g_sample': '2'}, 600),
-            ({'g_sample': '3'}, 700),
-            ({'g_sample': '1', 'g_subsample': 'b'}, 800),
+            ({"g_sample": "1"}, 500),
+            ({"g_sample": "2"}, 600),
+            ({"g_sample": "3"}, 700),
+            ({"g_sample": "1", "g_subsample": "b"}, 800),
         )
 
         summary_data = (
-            ({'s_sample': '1'}, range(1000, 2000, 4)),
-            ({'s_sample': '2'}, range(2000, 3000, 20)),
-            ({'s_sample': '3'}, range(3000, 4000, 13)),
-            ({'s_sample': '1', 's_subsample': 'b'}, range(4000, 5000, 47)),
+            ({"s_sample": "1"}, range(1000, 2000, 4)),
+            ({"s_sample": "2"}, range(2000, 3000, 20)),
+            ({"s_sample": "3"}, range(3000, 4000, 13)),
+            ({"s_sample": "1", "s_subsample": "b"}, range(4000, 5000, 47)),
         )
 
         registry = Registry()
-        counter = Counter("counter_test", "A counter.", {'type': "counter"})
-        gauge = Gauge("gauge_test", "A gauge.", {'type': "gauge"})
-        summary = Summary("summary_test", "A summary.", {'type': "summary"})
+        counter = Counter("counter_test", "A counter.", {"type": "counter"})
+        gauge = Gauge("gauge_test", "A gauge.", {"type": "gauge"})
+        summary = Summary("summary_test", "A summary.", {"type": "summary"})
 
         # Add data
         [counter.set(c[0], c[1]) for c in counter_data]

--- a/tests/test_metricdict.py
+++ b/tests/test_metricdict.py
@@ -14,16 +14,16 @@ class TestMetricDict(unittest.TestCase):
     def test_bad_keys(self):
         with self.assertRaises(TypeError) as context:
             metrics = MetricDict()
-            metrics['not_valid'] = "value"
+            metrics["not_valid"] = "value"
 
-        self.assertEqual('Only accepts dicts as keys', str(context.exception))
+        self.assertEqual("Only accepts dicts as keys", str(context.exception))
 
     def test_set(self):
         metrics = MetricDict()
         data = (
-            ({'a': 1}, 1000),
-            ({'b': 2, 'c': 3}, 2000),
-            ({'d': 4, 'e': 5, 'f': 6}, 3000),
+            ({"a": 1}, 1000),
+            ({"b": 2, "c": 3}, 2000),
+            ({"d": 4, "e": 5, "f": 6}, 3000),
         )
 
         for i in data:
@@ -34,9 +34,9 @@ class TestMetricDict(unittest.TestCase):
     def test_get(self):
         metrics = MetricDict()
         data = (
-            ({'a': 1}, 1000),
-            ({'b': 2, 'c': 3}, 2000),
-            ({'d': 4, 'e': 5, 'f': 6}, 3000),
+            ({"a": 1}, 1000),
+            ({"b": 2, "c": 3}, 2000),
+            ({"d": 4, "e": 5, "f": 6}, 3000),
         )
 
         for i in data:
@@ -47,7 +47,7 @@ class TestMetricDict(unittest.TestCase):
 
     def test_override(self):
         metrics = MetricDict()
-        key = {'a': 1}
+        key = {"a": 1}
 
         for i in range(100):
             metrics[key] = i
@@ -58,9 +58,9 @@ class TestMetricDict(unittest.TestCase):
     def test_similar(self):
         metrics = MetricDict()
         data = (
-            ({'d': 4, 'e': 5, 'f': 6}, 3000),
-            ({'e': 5, 'd': 4, 'f': 6}, 4000),
-            ({'d': 4, 'f': 6, 'e': 5}, 5000),
+            ({"d": 4, "e": 5, "f": 6}, 3000),
+            ({"e": 5, "d": 4, "f": 6}, 4000),
+            ({"d": 4, "f": 6, "e": 5}, 5000),
         )
 
         for i in data:
@@ -69,7 +69,7 @@ class TestMetricDict(unittest.TestCase):
         self.assertEqual(1, len(metrics))
 
     def test_access_by_str(self):
-        label = {'b': 2, 'c': 3, 'a': 1}
+        label = {"b": 2, "c": 3, "a": 1}
         access_key = '{"a": 1, "b": 2, "c": 3}'
         bad_access_key = '{"b": 2, "c": 3, "a": 1}'
         value = 100
@@ -79,8 +79,8 @@ class TestMetricDict(unittest.TestCase):
 
         # Wrong string
         with self.assertRaises(TypeError) as context:
-            metrics['dasdasd']
-        self.assertEqual('Only accepts dicts as keys', str(context.exception))
+            metrics["dasdasd"]
+        self.assertEqual("Only accepts dicts as keys", str(context.exception))
 
         # Access ok with string
         self.assertEqual(value, metrics[access_key])
@@ -88,8 +88,7 @@ class TestMetricDict(unittest.TestCase):
         # Access ok but wrong key by order
         with self.assertRaises(KeyError) as context:
             metrics[bad_access_key]
-        self.assertEqual("'{0}'".format(bad_access_key),
-                         str(context.exception))
+        self.assertEqual("'{0}'".format(bad_access_key), str(context.exception))
 
     def test_empty_key(self):
         metrics = MetricDict()
@@ -106,12 +105,12 @@ class TestMetricDict(unittest.TestCase):
     def test_delete(self):
         metrics = MetricDict()
         data = (
-            ({'d': 4, 'e': 5, 'f': 6}, 3000),
-            ({'e': 5, 'd': 4, 'f': 6}, 4000),
-            ({'d': 4, 'f': 6, 'e': 5}, 5000),
-            ({'d': 41, 'f': 61, 'e': 51}, 6000),
-            ({'d': 41, 'e': 51, 'f': 61}, 7000),
-            ({'f': 61, 'e': 51, 'd': 41}, 8000),
+            ({"d": 4, "e": 5, "f": 6}, 3000),
+            ({"e": 5, "d": 4, "f": 6}, 4000),
+            ({"d": 4, "f": 6, "e": 5}, 5000),
+            ({"d": 41, "f": 61, "e": 51}, 6000),
+            ({"d": 41, "e": 51, "f": 61}, 7000),
+            ({"f": 61, "e": 51, "d": 41}, 8000),
         )
 
         for i in data:
@@ -124,12 +123,12 @@ class TestMetricDict(unittest.TestCase):
     def test_all(self):
         metrics = MetricDict()
         data = (
-            ({'d': 4, 'e': 5, 'f': 6}, 3000),
-            ({'e': 5, 'd': 4, 'f': 6}, 4000),
-            ({'d': 4, 'f': 6, 'e': 5}, 5000),
-            ({'d': 41, 'f': 61, 'e': 51}, 6000),
-            ({'d': 41, 'e': 51, 'f': 61}, 7000),
-            ({'f': 61, 'e': 51, 'd': 41}, 8000),
+            ({"d": 4, "e": 5, "f": 6}, 3000),
+            ({"e": 5, "d": 4, "f": 6}, 4000),
+            ({"d": 4, "f": 6, "e": 5}, 5000),
+            ({"d": 41, "f": 61, "e": 51}, 6000),
+            ({"d": 41, "e": 51, "f": 61}, 7000),
+            ({"f": 61, "e": 51, "d": 41}, 8000),
         )
 
         for i in data:
@@ -137,5 +136,5 @@ class TestMetricDict(unittest.TestCase):
 
         self.assertEqual(2, len(metrics))
 
-        self.assertEqual(5000, metrics[{'d': 4, 'e': 5, 'f': 6}])
-        self.assertEqual(8000, metrics[{'d': 41, 'f': 61, 'e': 51}])
+        self.assertEqual(5000, metrics[{"d": 4, "e": 5, "f": 6}])
+        self.assertEqual(8000, metrics[{"d": 41, "f": 61, "e": 51}])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,37 +1,31 @@
 
 import unittest
 
-from aioprometheus import (
-    Collector,
-    Counter,
-    Gauge,
-    Histogram,
-    Registry,
-    Summary)
+from aioprometheus import Collector, Counter, Gauge, Histogram, Registry, Summary
 
 
 class TestCollectorDict(unittest.TestCase):
 
     def setUp(self):
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {"app": "my_app"},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {"app": "my_app"},
         }
 
         self.c = Collector(**self.data)
 
     def test_initialization(self):
-        self.assertEqual(self.data['name'], self.c.name)
-        self.assertEqual(self.data['doc'], self.c.doc)
-        self.assertEqual(self.data['const_labels'], self.c.const_labels)
+        self.assertEqual(self.data["name"], self.c.name)
+        self.assertEqual(self.data["doc"], self.c.doc)
+        self.assertEqual(self.data["const_labels"], self.c.const_labels)
 
     def test_set_value(self):
         data = (
-            ({'country': "sp", "device": "desktop"}, 520),
-            ({'country': "us", "device": "mobile"}, 654),
-            ({'country': "uk", "device": "desktop"}, 1001),
-            ({'country': "de", "device": "desktop"}, 995),
+            ({"country": "sp", "device": "desktop"}, 520),
+            ({"country": "us", "device": "mobile"}, 654),
+            ({"country": "uk", "device": "desktop"}, 1001),
+            ({"country": "de", "device": "desktop"}, 995),
         )
 
         for m in data:
@@ -41,10 +35,10 @@ class TestCollectorDict(unittest.TestCase):
 
     def test_same_value(self):
         data = (
-            ({'country': "sp", "device": "desktop", "ts": "GMT+1"}, 520),
-            ({"ts": "GMT+1", 'country': "sp", "device": "desktop"}, 521),
-            ({'country': "sp", "ts": "GMT+1", "device": "desktop"}, 522),
-            ({"device": "desktop", "ts": "GMT+1", 'country': "sp"}, 523),
+            ({"country": "sp", "device": "desktop", "ts": "GMT+1"}, 520),
+            ({"ts": "GMT+1", "country": "sp", "device": "desktop"}, 521),
+            ({"country": "sp", "ts": "GMT+1", "device": "desktop"}, 522),
+            ({"device": "desktop", "ts": "GMT+1", "country": "sp"}, 523),
         )
 
         for m in data:
@@ -55,10 +49,10 @@ class TestCollectorDict(unittest.TestCase):
 
     def test_get_value(self):
         data = (
-            ({'country': "sp", "device": "desktop"}, 520),
-            ({'country': "us", "device": "mobile"}, 654),
-            ({'country': "uk", "device": "desktop"}, 1001),
-            ({'country': "de", "device": "desktop"}, 995),
+            ({"country": "sp", "device": "desktop"}, 520),
+            ({"country": "us", "device": "mobile"}, 654),
+            ({"country": "uk", "device": "desktop"}, 1001),
+            ({"country": "de", "device": "desktop"}, 995),
         )
 
         for m in data:
@@ -68,33 +62,31 @@ class TestCollectorDict(unittest.TestCase):
             self.assertEqual(m[1], self.c.get_value(m[0]))
 
     def test_not_const_labels(self):
-        del self.data['const_labels']
+        del self.data["const_labels"]
         self.c = Collector(**self.data)
 
     def test_not_name(self):
         with self.assertRaises(TypeError) as context:
-            del self.data['name']
+            del self.data["name"]
             self.c = Collector(**self.data)
 
         self.assertEqual(
             "__init__() missing 1 required positional argument: 'name'",
-            str(context.exception))
+            str(context.exception),
+        )
 
     def test_not_help_text(self):
         with self.assertRaises(TypeError) as context:
-            del self.data['doc']
+            del self.data["doc"]
             self.c = Collector(**self.data)
 
         self.assertEqual(
             "__init__() missing 1 required positional argument: 'doc'",
-            str(context.exception))
+            str(context.exception),
+        )
 
     def test_without_labels(self):
-        data = (
-            ({}, 520),
-            (None, 654),
-            ("", 1001),
-        )
+        data = (({}, 520), (None, 654), ("", 1001))
 
         for i in data:
             self.c.set_value(i[0], i[1])
@@ -106,47 +98,48 @@ class TestCollectorDict(unittest.TestCase):
 
         # Normal set
         with self.assertRaises(ValueError) as context:
-            self.c.set_value({'job': 1, 'ok': 2}, 1)
+            self.c.set_value({"job": 1, "ok": 2}, 1)
 
-        self.assertEqual('Invalid label name: job', str(context.exception))
+        self.assertEqual("Invalid label name: job", str(context.exception))
 
         with self.assertRaises(ValueError) as context:
-            self.c.set_value({'__not_ok': 1, 'ok': 2}, 1)
+            self.c.set_value({"__not_ok": 1, "ok": 2}, 1)
 
-        self.assertEqual('Invalid label prefix: __not_ok', str(context.exception))
+        self.assertEqual("Invalid label prefix: __not_ok", str(context.exception))
 
         # Constructor set
         with self.assertRaises(ValueError) as context:
-            Collector("x", "y", {'job': 1, 'ok': 2})
+            Collector("x", "y", {"job": 1, "ok": 2})
 
-        self.assertEqual('Invalid label name: job', str(context.exception))
+        self.assertEqual("Invalid label name: job", str(context.exception))
 
         with self.assertRaises(ValueError) as context:
-            Collector("x", "y", {'__not_ok': 1, 'ok': 2})
+            Collector("x", "y", {"__not_ok": 1, "ok": 2})
 
-        self.assertEqual('Invalid label prefix: __not_ok', str(context.exception))
+        self.assertEqual("Invalid label prefix: __not_ok", str(context.exception))
 
     def test_get_all(self):
         data = (
-            ({'country': "sp", "device": "desktop"}, 520),
-            ({'country': "us", "device": "mobile"}, 654),
-            ({'country': "uk", "device": "desktop"}, 1001),
-            ({'country': "de", "device": "desktop"}, 995),
-            ({'country': "zh", "device": "desktop"}, 520),
-            ({'country': "ch", "device": "mobile"}, 654),
-            ({'country': "ca", "device": "desktop"}, 1001),
-            ({'country': "jp", "device": "desktop"}, 995),
-            ({'country': "au", "device": "desktop"}, 520),
-            ({'country': "py", "device": "mobile"}, 654),
-            ({'country': "ar", "device": "desktop"}, 1001),
-            ({'country': "pt", "device": "desktop"}, 995),
+            ({"country": "sp", "device": "desktop"}, 520),
+            ({"country": "us", "device": "mobile"}, 654),
+            ({"country": "uk", "device": "desktop"}, 1001),
+            ({"country": "de", "device": "desktop"}, 995),
+            ({"country": "zh", "device": "desktop"}, 520),
+            ({"country": "ch", "device": "mobile"}, 654),
+            ({"country": "ca", "device": "desktop"}, 1001),
+            ({"country": "jp", "device": "desktop"}, 995),
+            ({"country": "au", "device": "desktop"}, 520),
+            ({"country": "py", "device": "mobile"}, 654),
+            ({"country": "ar", "device": "desktop"}, 1001),
+            ({"country": "pt", "device": "desktop"}, 995),
         )
 
         for i in data:
             self.c.set_value(i[0], i[1])
 
         def country_fetcher(x):
-            return x[0]['country']
+            return x[0]["country"]
+
         sorted_data = sorted(data, key=country_fetcher)
         sorted_result = sorted(self.c.get_all(), key=country_fetcher)
         self.assertEqual(sorted_data, sorted_result)
@@ -156,9 +149,9 @@ class TestCounter(unittest.TestCase):
 
     def setUp(self):
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {"app": "my_app"},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {"app": "my_app"},
         }
 
         self.c = Counter(**self.data)
@@ -166,67 +159,46 @@ class TestCounter(unittest.TestCase):
     def test_set(self):
 
         data = (
-            {
-                'labels': {'country': "sp", "device": "desktop"},
-                'values': range(10)
-            },
-            {
-                'labels': {'country': "us", "device": "mobile"},
-                'values': range(10, 20)
-            },
-            {
-                'labels': {'country': "uk", "device": "desktop"},
-                'values': range(20, 30)
-            }
+            {"labels": {"country": "sp", "device": "desktop"}, "values": range(10)},
+            {"labels": {"country": "us", "device": "mobile"}, "values": range(10, 20)},
+            {"labels": {"country": "uk", "device": "desktop"}, "values": range(20, 30)},
         )
 
         for i in data:
-            for j in i['values']:
-                self.c.set(i['labels'], j)
+            for j in i["values"]:
+                self.c.set(i["labels"], j)
 
         self.assertEqual(len(data), len(self.c.values))
 
     def test_get(self):
         data = (
-            {
-                'labels': {'country': "sp", "device": "desktop"},
-                'values': range(10)
-            },
-            {
-                'labels': {'country': "us", "device": "mobile"},
-                'values': range(10, 20)
-            },
-            {
-                'labels': {'country': "uk", "device": "desktop"},
-                'values': range(20, 30)
-            }
+            {"labels": {"country": "sp", "device": "desktop"}, "values": range(10)},
+            {"labels": {"country": "us", "device": "mobile"}, "values": range(10, 20)},
+            {"labels": {"country": "uk", "device": "desktop"}, "values": range(20, 30)},
         )
 
         for i in data:
-            for j in i['values']:
-                self.c.set(i['labels'], j)
-                self.assertEqual(j, self.c.get(i['labels']))
+            for j in i["values"]:
+                self.c.set(i["labels"], j)
+                self.assertEqual(j, self.c.get(i["labels"]))
 
         # Last check
         for i in data:
-            self.assertEqual(max(i['values']), self.c.get(i['labels']))
+            self.assertEqual(max(i["values"]), self.c.get(i["labels"]))
 
     def test_set_get_without_labels(self):
-        data = {
-            'labels': {},
-            'values': range(100)
-        }
+        data = {"labels": {}, "values": range(100)}
 
-        for i in data['values']:
-            self.c.set(data['labels'], i)
+        for i in data["values"]:
+            self.c.set(data["labels"], i)
 
         self.assertEqual(1, len(self.c.values))
 
-        self.assertEqual(max(data['values']), self.c.get(data['labels']))
+        self.assertEqual(max(data["values"]), self.c.get(data["labels"]))
 
     def test_inc(self):
         iterations = 100
-        labels = {'country': "sp", "device": "desktop"}
+        labels = {"country": "sp", "device": "desktop"}
 
         for i in range(iterations):
             self.c.inc(labels)
@@ -234,7 +206,7 @@ class TestCounter(unittest.TestCase):
         self.assertEqual(iterations, self.c.get(labels))
 
     def test_add(self):
-        labels = {'country': "sp", "device": "desktop"}
+        labels = {"country": "sp", "device": "desktop"}
         iterations = 100
 
         for i in range(iterations):
@@ -243,86 +215,65 @@ class TestCounter(unittest.TestCase):
         self.assertEqual(sum(range(iterations)), self.c.get(labels))
 
     def test_negative_add(self):
-        labels = {'country': "sp", "device": "desktop"}
+        labels = {"country": "sp", "device": "desktop"}
 
         with self.assertRaises(ValueError) as context:
             self.c.add(labels, -1)
-        self.assertEqual('Counters can\'t decrease', str(context.exception))
+        self.assertEqual("Counters can't decrease", str(context.exception))
 
 
 class TestGauge(unittest.TestCase):
 
     def setUp(self):
         self.data = {
-            'name': "hdd_disk_used",
-            'doc': "Disk space used",
-            'const_labels': {"server": "1.db.production.my-app"},
+            "name": "hdd_disk_used",
+            "doc": "Disk space used",
+            "const_labels": {"server": "1.db.production.my-app"},
         }
 
         self.g = Gauge(**self.data)
 
     def test_set(self):
         data = (
-            {
-                'labels': {'max': "500G", 'dev': "sda"},
-                'values': range(0, 500, 50)
-            },
-            {
-                'labels': {'max': "1T", 'dev': "sdb"},
-                'values': range(0, 1000, 100)
-            },
-            {
-                'labels': {'max': "10T", 'dev': "sdc"},
-                'values': range(0, 10000, 1000)
-            }
+            {"labels": {"max": "500G", "dev": "sda"}, "values": range(0, 500, 50)},
+            {"labels": {"max": "1T", "dev": "sdb"}, "values": range(0, 1000, 100)},
+            {"labels": {"max": "10T", "dev": "sdc"}, "values": range(0, 10000, 1000)},
         )
 
         for i in data:
-            for j in i['values']:
-                self.g.set(i['labels'], j)
+            for j in i["values"]:
+                self.g.set(i["labels"], j)
 
         self.assertEqual(len(data), len(self.g.values))
 
     def test_get(self):
         data = (
-            {
-                'labels': {'max': "500G", 'dev': "sda"},
-                'values': range(0, 500, 50)
-            },
-            {
-                'labels': {'max': "1T", 'dev': "sdb"},
-                'values': range(0, 1000, 100)
-            },
-            {
-                'labels': {'max': "10T", 'dev': "sdc"},
-                'values': range(0, 10000, 1000)
-            }
+            {"labels": {"max": "500G", "dev": "sda"}, "values": range(0, 500, 50)},
+            {"labels": {"max": "1T", "dev": "sdb"}, "values": range(0, 1000, 100)},
+            {"labels": {"max": "10T", "dev": "sdc"}, "values": range(0, 10000, 1000)},
         )
 
         for i in data:
-            for j in i['values']:
-                self.g.set(i['labels'], j)
-                self.assertEqual(j, self.g.get(i['labels']))
+            for j in i["values"]:
+                self.g.set(i["labels"], j)
+                self.assertEqual(j, self.g.get(i["labels"]))
 
         for i in data:
-            self.assertEqual(max(i['values']), self.g.get(i['labels']))
+            self.assertEqual(max(i["values"]), self.g.get(i["labels"]))
 
     def test_set_get_without_labels(self):
-        data = {
-            'labels': {},
-            'values': range(100)
-        }
+        data = {"labels": {}, "values": range(100)}
 
-        for i in data['values']:
-            self.g.set(data['labels'], i)
+        for i in data["values"]:
+            self.g.set(data["labels"], i)
 
         self.assertEqual(1, len(self.g.values))
 
-        self.assertEqual(max(data['values']), self.g.get(data['labels']))
+        self.assertEqual(max(data["values"]), self.g.get(data["labels"]))
 
     def test_inc(self):
         iterations = 100
-        labels = {'max': "10T", 'dev': "sdc"}
+        labels = {"max": "10T", "dev": "sdc"}
 
         for i in range(iterations):
             self.g.inc(labels)
@@ -332,7 +283,7 @@ class TestGauge(unittest.TestCase):
 
     def test_dec(self):
         iterations = 100
-        labels = {'max': "10T", 'dev': "sdc"}
+        labels = {"max": "10T", "dev": "sdc"}
         self.g.set(labels, iterations)
 
         for i in range(iterations):
@@ -343,7 +294,7 @@ class TestGauge(unittest.TestCase):
 
     def test_add(self):
         iterations = 100
-        labels = {'max': "10T", 'dev': "sdc"}
+        labels = {"max": "10T", "dev": "sdc"}
 
         for i in range(iterations):
             self.g.add(labels, i)
@@ -352,27 +303,25 @@ class TestGauge(unittest.TestCase):
 
     def test_add_negative(self):
         iterations = 100
-        labels = {'max': "10T", 'dev': "sdc"}
+        labels = {"max": "10T", "dev": "sdc"}
 
         for i in range(iterations):
             self.g.add(labels, -i)
 
-        self.assertEqual(sum(map(lambda x: -x, range(iterations))),
-                         self.g.get(labels))
+        self.assertEqual(sum(map(lambda x: -x, range(iterations))), self.g.get(labels))
 
     def test_sub(self):
         iterations = 100
-        labels = {'max': "10T", 'dev': "sdc"}
+        labels = {"max": "10T", "dev": "sdc"}
 
         for i in range(iterations):
             self.g.sub(labels, i)
 
-        self.assertEqual(sum(map(lambda x: -x, range(iterations))),
-                         self.g.get(labels))
+        self.assertEqual(sum(map(lambda x: -x, range(iterations))), self.g.get(labels))
 
     def test_sub_positive(self):
         iterations = 100
-        labels = {'max': "10T", 'dev': "sdc"}
+        labels = {"max": "10T", "dev": "sdc"}
 
         for i in range(iterations):
             self.g.sub(labels, -i)
@@ -384,52 +333,36 @@ class TestSummary(unittest.TestCase):
 
     def setUp(self):
         self.data = {
-            'name': "http_request_duration_microseconds",
-            'doc': "Request duration per application",
-            'const_labels': {"app": "my_app"},
+            "name": "http_request_duration_microseconds",
+            "doc": "Request duration per application",
+            "const_labels": {"app": "my_app"},
         }
 
         self.s = Summary(**self.data)
 
     def test_add(self):
         data = (
-            {
-                'labels': {'handler': '/static'},
-                'values': range(0, 500, 50)
-            },
-            {
-                'labels': {'handler': '/p'},
-                'values': range(0, 1000, 100)
-            },
-            {
-                'labels': {'handler': '/p/login'},
-                'values': range(0, 10000, 1000)
-            }
+            {"labels": {"handler": "/static"}, "values": range(0, 500, 50)},
+            {"labels": {"handler": "/p"}, "values": range(0, 1000, 100)},
+            {"labels": {"handler": "/p/login"}, "values": range(0, 10000, 1000)},
         )
 
         for i in data:
-            for j in i['values']:
-                self.s.add(i['labels'], j)
+            for j in i["values"]:
+                self.s.add(i["labels"], j)
 
         for i in data:
-            self.assertEqual(len(i['values']),
-                             self.s.values[i['labels']]._observations)
+            self.assertEqual(len(i["values"]), self.s.values[i["labels"]]._observations)
 
     def test_get(self):
-        labels = {'handler': '/static'}
+        labels = {"handler": "/static"}
         values = [3, 5.2, 13, 4]
 
         for i in values:
-                self.s.add(labels, i)
+            self.s.add(labels, i)
 
         data = self.s.get(labels)
-        correct_data = {
-            'sum': 25.2,
-            'count': 4,
-            0.50: 4.0,
-            0.90: 5.2,
-            0.99: 5.2,
-        }
+        correct_data = {"sum": 25.2, "count": 4, 0.50: 4.0, 0.90: 5.2, 0.99: 5.2}
 
         self.assertEqual(correct_data, data)
 
@@ -442,33 +375,28 @@ class TestSummary(unittest.TestCase):
 
         self.assertEqual(1, len(self.s.values))
 
-        correct_data = {
-            'sum': 25.2,
-            'count': 4,
-            0.50: 4.0,
-            0.90: 5.2,
-            0.99: 5.2,
-        }
+        correct_data = {"sum": 25.2, "count": 4, 0.50: 4.0, 0.90: 5.2, 0.99: 5.2}
         self.assertEqual(correct_data, self.s.get(labels))
 
     def test_add_wrong_types(self):
         labels = None
-        values = ["3", (1, 2), {'1': 2}, True]
+        values = ["3", (1, 2), {"1": 2}, True]
 
         for i in values:
             with self.assertRaises(TypeError) as context:
                 self.s.add(labels, i)
-        self.assertEqual("Summary only works with digits (int, float)",
-                         str(context.exception))
+        self.assertEqual(
+            "Summary only works with digits (int, float)", str(context.exception)
+        )
 
 
 class TestHistogram(unittest.TestCase):
 
     def setUp(self):
         self.data = {
-            'name': "http_request_duration_microseconds",
-            'doc': "Request duration per application",
-            'const_labels': {"app": "my_app"},
+            "name": "http_request_duration_microseconds",
+            "doc": "Request duration per application",
+            "const_labels": {"app": "my_app"},
         }
 
         self.h = Histogram(**self.data)
@@ -476,6 +404,6 @@ class TestHistogram(unittest.TestCase):
     def test_wrong_labels(self):
 
         with self.assertRaises(ValueError) as context:
-            self.h.set_value({'le': 2}, 1)
+            self.h.set_value({"le": 2}, 1)
 
-        self.assertEqual('Invalid label name: le', str(context.exception))
+        self.assertEqual("Invalid label name: le", str(context.exception))

--- a/tests/test_negotiate.py
+++ b/tests/test_negotiate.py
@@ -8,48 +8,42 @@ from aioprometheus.formats import TextFormatter, BinaryFormatter
 class TestNegotiate(unittest.TestCase):
 
     def test_protobuffer(self):
-        ''' check that a protobuf formatter is returned '''
+        """ check that a protobuf formatter is returned """
         headers = (
             "proto=io.prometheus.client.MetricFamily;application/vnd.google.protobuf;encoding=delimited",
             "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited",
-            "encoding=delimited;application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily")
+            "encoding=delimited;application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily",
+        )
 
         for accept in headers:
-            self.assertEqual(
-                BinaryFormatter, negotiate(set(accept.split(';'))))
+            self.assertEqual(BinaryFormatter, negotiate(set(accept.split(";"))))
 
     def test_text_004(self):
-        ''' check that a text formatter is returned for version 0.0.4 '''
+        """ check that a text formatter is returned for version 0.0.4 """
         headers = (
             "text/plain; version=0.0.4",
             "text/plain;version=0.0.4",
-            "version=0.0.4; text/plain")
+            "version=0.0.4; text/plain",
+        )
 
         for accept in headers:
-            self.assertEqual(
-                TextFormatter, negotiate(set(accept.split(';'))))
+            self.assertEqual(TextFormatter, negotiate(set(accept.split(";"))))
 
     def test_text_default(self):
-        ''' check that a text formatter is returned for plain text '''
-        headers = (
-            "text/plain;",)
+        """ check that a text formatter is returned for plain text """
+        headers = ("text/plain;",)
 
         for accept in headers:
-            self.assertEqual(
-                TextFormatter, negotiate(set(accept.split(';'))))
+            self.assertEqual(TextFormatter, negotiate(set(accept.split(";"))))
 
     def test_default(self):
-        ''' check that a text formatter is returned if no matches '''
-        headers = (
-            "application/json",
-            "*/*",
-            "application/nothing")
+        """ check that a text formatter is returned if no matches """
+        headers = ("application/json", "*/*", "application/nothing")
 
         for accept in headers:
-            self.assertEqual(
-                TextFormatter, negotiate(set(accept.split(';'))))
+            self.assertEqual(TextFormatter, negotiate(set(accept.split(";"))))
 
     def test_no_accept_header(self):
-        ''' check request with no accept header works '''
+        """ check request with no accept header works """
         self.assertEqual(TextFormatter, negotiate(set()))
-        self.assertEqual(TextFormatter, negotiate(set(['', ])))
+        self.assertEqual(TextFormatter, negotiate(set([""])))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,28 +1,22 @@
 import unittest
 
-from aioprometheus import (
-    CollectorRegistry,
-    Collector,
-    Counter,
-    Gauge,
-    Summary)
+from aioprometheus import CollectorRegistry, Collector, Counter, Gauge, Summary
 
 
 class TestRegistry(unittest.TestCase):
 
     def setUp(self):
         self.data = {
-            'name': "logged_users_total",
-            'doc': "Logged users in the application",
-            'const_labels': {"app": "my_app"},
+            "name": "logged_users_total",
+            "doc": "Logged users in the application",
+            "const_labels": {"app": "my_app"},
         }
 
     def test_register(self):
-        ''' check collectors can be registered '''
+        """ check collectors can be registered """
 
         q = 100
-        collectors = [
-            Collector('test' + str(i), 'Test' + str(i)) for i in range(q)]
+        collectors = [Collector("test" + str(i), "Test" + str(i)) for i in range(q)]
 
         r = CollectorRegistry()
 
@@ -32,7 +26,7 @@ class TestRegistry(unittest.TestCase):
         self.assertEqual(q, len(r.collectors))
 
     def test_register_sames(self):
-        ''' check registering same metrics raises exceptoion '''
+        """ check registering same metrics raises exceptoion """
         r = CollectorRegistry()
 
         r.register(Collector(**self.data))
@@ -41,46 +35,45 @@ class TestRegistry(unittest.TestCase):
             r.register(Collector(**self.data))
 
         self.assertEqual(
-            "Collector {} is already registered".format(self.data['name']),
-            str(context.exception))
+            "Collector {} is already registered".format(self.data["name"]),
+            str(context.exception),
+        )
 
     def test_register_counter(self):
-        ''' check registering a counter collector '''
+        """ check registering a counter collector """
         r = CollectorRegistry()
         r.register(Counter(**self.data))
 
         self.assertEqual(1, len(r.collectors))
 
     def test_register_gauge(self):
-        ''' check registering a gauge collector '''
+        """ check registering a gauge collector """
         r = CollectorRegistry()
         r.register(Gauge(**self.data))
 
         self.assertEqual(1, len(r.collectors))
 
     def test_register_summary(self):
-        ''' check registering a summary collector '''
+        """ check registering a summary collector """
         r = CollectorRegistry()
         r.register(Summary(**self.data))
 
         self.assertEqual(1, len(r.collectors))
 
     def test_register_wrong_type(self):
-        ''' check registering an invalid collector raises an exception '''
+        """ check registering an invalid collector raises an exception """
         r = CollectorRegistry()
 
         with self.assertRaises(TypeError) as context:
             r.register("This will fail")
-        self.assertIn(
-            "Invalid collector type: ",
-            str(context.exception))
+        self.assertIn("Invalid collector type: ", str(context.exception))
 
     def test_deregister(self):
-        ''' check collectors can be deregistered '''
+        """ check collectors can be deregistered """
         r = CollectorRegistry()
         r.register(Collector(**self.data))
 
-        r.deregister(self.data['name'])
+        r.deregister(self.data["name"])
 
         self.assertEqual(0, len(r.collectors))
 
@@ -93,8 +86,7 @@ class TestRegistry(unittest.TestCase):
 
     def test_get_all(self):
         q = 100
-        collectors = [
-            Collector('test' + str(i), 'Test' + str(i)) for i in range(q)]
+        collectors = [Collector("test" + str(i), "Test" + str(i)) for i in range(q)]
 
         r = CollectorRegistry()
 


### PR DESCRIPTION
This merge request converts the project from using ``pycodestyle`` and ``autopep8`` to using just ``black`` for code style formatting. 
- The ``black`` foramtter has been run over the code. No functional changes are present, this is a formatting only change.
- The Makefile is simplified. 
  - The ``make style`` and ``make style.fix`` have been combined into the single rule ``make style``.
  -  the ``make style.fex`` rule has been removed
  - The ``.PHONY:`` directives have been moved to be above the actual rule which helps maintenance of the Makefile.
- The developer docs are updated to describe the code style checking step.
- pyp3 support is something being investigated. Currently the travis build fails for some weird reason that can not be replicated locally with pypy3. The travis config has been changed to allow the pypy build to fail.