### PR TITLE
add readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+build:
+  image: latest
+python:
+  version: 3.6
+  pip_install: true
+formats: []

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def parse_requirements(filename):
     with open(filename, 'r') as fd:
         lines = []
         for line in fd:
-            line.strip()
+            line = line.strip()
             if line and not line.startswith("#"):
                 lines.append(line)
     return lines


### PR DESCRIPTION
The docs hosted on ReadTheDocs is failing due to the default configuration using Python3.5 while the project now depends on ``aiohttp`` 3.2.1 which requires a minimum of Python 3.6.

Define a configuration file for ReadTheDocs that uses Python3.6.

Also, fix a minor issue parsing the requirements file that was observed in the ``setup.py`` file. 