### PR TITLE
Fix histogram

### DIFF
--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -39,7 +39,7 @@ commands are pointing at the correct tools.
     $ python -m venv myvenv
     $ cd myvenv
     $ source bin/activate
-    $ cd ..
+    (myvenv) $ cd ..
 
 To exit the virtual environment simply type ``deactivate``.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,9 +91,9 @@ to read on the command line.
     $ curl http://127.0.0.1:50624/metrics -H "ACCEPT: application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited"
 
 The metrics service also responds to requests sent to its ``/`` route. The
-response is simple HTML. This route can be useful as a Kubernetes ``/healthz``
-style health indicator as it does not incur any overhead within the service
-to serialize a full metrics response.
+response is simple HTML. This route can be useful as a Kubernetes health
+indicator as it does not incur any overhead within the service to
+serialize a full metrics response.
 
 .. code-block:: console
 

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -83,7 +83,19 @@ A summary metrics provides:
     from aioprometheus import Summary
 
     http_access =  Summary("http_access_time", "HTTP access time")
-    http_access.add({'time': '/static'}, 3.142)
+    http_access.observe({'time': '/static'}, 3.142)
+
+The default invariants ([(0.50, 0.05), (0.90, 0.01), (0.99, 0.001)])
+can be overridden by passing `invariants` keyword argument to Summary.
+
+.. code-block:: python
+
+    from aioprometheus import Summary
+
+    http_access =  Summary(
+        "http_access_time",
+        "HTTP access time",
+        invariants=[(0.50, 0.05), (0.99, 0.001)])
 
 
 Histogram
@@ -91,16 +103,29 @@ Histogram
 
 A Histogram tracks the size and number of events in buckets.
 
-You can use Histograms for aggregatable calculation of quantiles. The set
-of buckets used can be overridden by passing `buckets` keyword argument to
-``Histogram``.
+You can use Histograms for aggregatable calculation of quantiles.
+
 
 .. code-block:: python
 
     from aioprometheus import Histogram
 
     http_access =  Histogram("http_access_time", "HTTP access time")
-    http_access.add({'time': '/static'}, 3.142)
+    http_access.observe({'time': '/static'}, 3.142)
+
+The default buckets cover the range 0.005, 0.01, 0.025, 0.05, 0.1,
+0.25, 0.5, 1.0, 2.5, 5.0, 10.0. All bucket ranges will include a
++Inf bucket. The buckets can be overridden by passing `buckets` keyword
+argument to Histogram.
+
+.. code-block:: python
+
+    from aioprometheus import Histogram
+
+    http_access =  Histogram(
+        "http_access_time",
+        "HTTP access time",
+        buckets=[0.1, 0.5, 1.0, 5.0])
 
 
 Labels

--- a/src/aioprometheus/__init__.py
+++ b/src/aioprometheus/__init__.py
@@ -8,4 +8,4 @@ from .registry import Registry, CollectorRegistry
 from .service import Service
 
 
-__version__ = "18.01.03"
+__version__ = "18.01.04"

--- a/src/aioprometheus/histogram.py
+++ b/src/aioprometheus/histogram.py
@@ -75,17 +75,14 @@ class Histogram(object):
     def observe(self, value: Union[float, int]) -> None:
         """ Observe the given amount.
 
-        Observing a value into the histogram will increment the count of
-        observations, add the value to the sum of all observations and
-        increment the appropriate bucket counter.
+        Observing a value into the histogram will cumulatively increment the
+        count of observations for the buckets that the observed values falls
+        within. It also adds the value to the sum of all observations.
 
         :param value: A metric value to add to the histogram.
         """
-        # The last bucket is +Inf, so we will always increment at least
-        # one bucket
         for upper_bound in self.buckets:
             if value <= upper_bound:
                 self.buckets[upper_bound] += 1
-                break
         self.sum += value
         self.observations += 1

--- a/src/aioprometheus/service.py
+++ b/src/aioprometheus/service.py
@@ -11,7 +11,7 @@ from aiohttp.hdrs import METH_GET as GET, ACCEPT
 
 from .negotiator import negotiate
 from .registry import Registry, CollectorsType
-from typing import Set
+from typing import Optional, Set
 
 # imports only used for type annotations
 from asyncio.base_events import BaseEventLoop, Server
@@ -51,9 +51,9 @@ class Service(object):
         self._site = None  # type: Server
         self._app = None  # type: aiohttp.web.Application
         self._runner = None  # type: aiohttp.web.RequestHandlerFactory
-        self._https = None  # type: bool
+        self._https = None  # type: Optional[bool]
         self._root_url = "/"
-        self._metrics_url = None  # type: str
+        self._metrics_url = None  # type: Optional[str]
 
     @property
     def base_url(self) -> str:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -12,7 +12,6 @@ from aioprometheus import (
 
 
 class TestDecorators(asynctest.TestCase):
-
     async def test_timer(self):
         m = Summary("metric_label", "metric help")
 
@@ -28,7 +27,6 @@ class TestDecorators(asynctest.TestCase):
 
         # decorator should work methods as well as functions
         class B(object):
-
             @timer(m, {"kind": "method"})
             async def b(self, arg1, arg2=None):
                 return arg1 == "b_arg", arg2 == "arg_2"
@@ -68,7 +66,6 @@ class TestDecorators(asynctest.TestCase):
 
         # decorator should work methods as well as functions
         class B(object):
-
             @inprogress(m, {"kind": "method"})
             async def b(self, arg1, arg2=None):
                 return arg1 == "b_arg", arg2 == "arg_2"
@@ -118,7 +115,6 @@ class TestDecorators(asynctest.TestCase):
 
         # decorator should work methods as well as functions
         class B(object):
-
             @count_exceptions(m, {"kind": "method"})
             async def b(self, arg1, arg2=None, raise_exc=False):
                 if raise_exc:

--- a/tests/test_formats_binary.py
+++ b/tests/test_formats_binary.py
@@ -11,7 +11,6 @@ TEST_TIMESTAMP = 1515044377268
 
 
 class TestProtobufFormat(unittest.TestCase):
-
     def setUp(self):
 
         self.const_labels = {"app": "my_app"}
@@ -56,7 +55,7 @@ class TestProtobufFormat(unittest.TestCase):
         self.histogram_metric_data = (
             (
                 {"route": "/"},
-                {5.0: 2, 10.0: 1, 15.0: 1, POS_INF: 0, "sum": 25.2, "count": 4},
+                {5.0: 2, 10.0: 3, 15.0: 4, POS_INF: 4, "sum": 25.2, "count": 4},
             ),
         )
         self.histogram_metric_data_values = (({"route": "/"}, (3, 5.2, 13, 4)),)
@@ -599,9 +598,9 @@ class TestProtobufFormat(unittest.TestCase):
             b"\x0bh_subsample\x12\x01b\n\x11\n\x04type\x12\t"
             b"histogram:?\x08\x06\x11\x00\x00\x00\x00\x00\x00G@"
             b"\x1a\x0b\x08\x03\x11\x00\x00\x00\x00\x00\x00\x14@"
-            b"\x1a\x0b\x08\x02\x11\x00\x00\x00\x00\x00\x00$@\x1a"
-            b"\x0b\x08\x01\x11\x00\x00\x00\x00\x00\x00.@\x1a\x0b"
-            b"\x08\x00\x11\x00\x00\x00\x00\x00\x00\xf0\x7f"
+            b"\x1a\x0b\x08\x05\x11\x00\x00\x00\x00\x00\x00$@\x1a"
+            b"\x0b\x08\x06\x11\x00\x00\x00\x00\x00\x00.@\x1a\x0b"
+            b"\x08\x06\x11\x00\x00\x00\x00\x00\x00\xf0\x7f"
         )
 
         f = BinaryFormatter()

--- a/tests/test_formats_text.py
+++ b/tests/test_formats_text.py
@@ -6,7 +6,6 @@ from aioprometheus.formats import TextFormatter, TEXT_CONTENT_TYPE
 
 
 class TestTextFormat(unittest.TestCase):
-
     def test_headers(self):
         f = TextFormatter()
         expected_result = {"Content-Type": TEXT_CONTENT_TYPE}
@@ -547,11 +546,11 @@ prometheus_local_storage_indexing_queue_capacity 16384"""
 
         valid_result = """# HELP prometheus_target_interval_length_seconds Actual intervals between scrapes.
 # TYPE prometheus_target_interval_length_seconds summary
-prometheus_target_interval_length_seconds_count{interval="5s"} 4
-prometheus_target_interval_length_seconds_sum{interval="5s"} 25.2
 prometheus_target_interval_length_seconds{interval="5s",quantile="0.5"} 4.0
 prometheus_target_interval_length_seconds{interval="5s",quantile="0.9"} 5.2
-prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2"""
+prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2
+prometheus_target_interval_length_seconds_count{interval="5s"} 4
+prometheus_target_interval_length_seconds_sum{interval="5s"} 25.2"""
 
         s = Summary(**data)
 
@@ -652,11 +651,11 @@ prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2"""
 
         result_regex = r"""# HELP prometheus_target_interval_length_seconds Actual intervals between scrapes.
 # TYPE prometheus_target_interval_length_seconds summary
-prometheus_target_interval_length_seconds_count{interval="5s"} 4 \d*(?:.\d*)?
-prometheus_target_interval_length_seconds_sum{interval="5s"} 25.2 \d*(?:.\d*)?
 prometheus_target_interval_length_seconds{interval="5s",quantile="0.5"} 4.0 \d*(?:.\d*)?
 prometheus_target_interval_length_seconds{interval="5s",quantile="0.9"} 5.2 \d*(?:.\d*)?
-prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2 \d*(?:.\d*)?$"""
+prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2 \d*(?:.\d*)?
+prometheus_target_interval_length_seconds_count{interval="5s"} 4 \d*(?:.\d*)?
+prometheus_target_interval_length_seconds_sum{interval="5s"} 25.2 \d*(?:.\d*)?$"""
 
         s = Summary(**data)
 
@@ -670,7 +669,7 @@ prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2 \d*
 
     def test_registry_marshall(self):
 
-        format_times = 10
+        format_times = 3
 
         counter_data = (
             ({"c_sample": "1"}, 100),
@@ -709,41 +708,42 @@ prometheus_target_interval_length_seconds{interval="5s",quantile="0.99"} 5.2 \d*
 
         valid_regex = r"""# HELP counter_test A counter.
 # TYPE counter_test counter
-counter_test{c_sample="1",c_subsample="b",type="counter"} 400
 counter_test{c_sample="1",type="counter"} 100
 counter_test{c_sample="2",type="counter"} 200
 counter_test{c_sample="3",type="counter"} 300
+counter_test{c_sample="1",c_subsample="b",type="counter"} 400
 # HELP gauge_test A gauge.
 # TYPE gauge_test gauge
-gauge_test{g_sample="1",g_subsample="b",type="gauge"} 800
 gauge_test{g_sample="1",type="gauge"} 500
 gauge_test{g_sample="2",type="gauge"} 600
 gauge_test{g_sample="3",type="gauge"} 700
+gauge_test{g_sample="1",g_subsample="b",type="gauge"} 800
 # HELP summary_test A summary.
 # TYPE summary_test summary
-summary_test_count{s_sample="1",s_subsample="b",type="summary"} \d*(?:.\d*)?
+summary_test{quantile="0.5",s_sample="1",type="summary"} \d*(?:.\d*)?
+summary_test{quantile="0.9",s_sample="1",type="summary"} \d*(?:.\d*)?
+summary_test{quantile="0.99",s_sample="1",type="summary"} \d*(?:.\d*)?
 summary_test_count{s_sample="1",type="summary"} \d*(?:.\d*)?
-summary_test_count{s_sample="2",type="summary"} \d*(?:.\d*)?
-summary_test_count{s_sample="3",type="summary"} \d*(?:.\d*)?
-summary_test_sum{s_sample="1",s_subsample="b",type="summary"} \d*(?:.\d*)?
 summary_test_sum{s_sample="1",type="summary"} \d*(?:.\d*)?
+summary_test{quantile="0.5",s_sample="2",type="summary"} \d*(?:.\d*)?
+summary_test{quantile="0.9",s_sample="2",type="summary"} 2\d*(?:.\d*)?
+summary_test{quantile="0.99",s_sample="2",type="summary"} \d*(?:.\d*)?
+summary_test_count{s_sample="2",type="summary"} \d*(?:.\d*)?
 summary_test_sum{s_sample="2",type="summary"} \d*(?:.\d*)?
+summary_test{quantile="0.5",s_sample="3",type="summary"} \d*(?:.\d*)?
+summary_test{quantile="0.9",s_sample="3",type="summary"} \d*(?:.\d*)?
+summary_test{quantile="0.99",s_sample="3",type="summary"} \d*(?:.\d*)?
+summary_test_count{s_sample="3",type="summary"} \d*(?:.\d*)?
 summary_test_sum{s_sample="3",type="summary"} \d*(?:.\d*)?
 summary_test{quantile="0.5",s_sample="1",s_subsample="b",type="summary"} \d*(?:.\d*)?
-summary_test{quantile="0.5",s_sample="1",type="summary"} \d*(?:.\d*)?
-summary_test{quantile="0.5",s_sample="2",type="summary"} \d*(?:.\d*)?
-summary_test{quantile="0.5",s_sample="3",type="summary"} \d*(?:.\d*)?
 summary_test{quantile="0.9",s_sample="1",s_subsample="b",type="summary"} \d*(?:.\d*)?
-summary_test{quantile="0.9",s_sample="1",type="summary"} \d*(?:.\d*)?
-summary_test{quantile="0.9",s_sample="2",type="summary"} 2\d*(?:.\d*)?
-summary_test{quantile="0.9",s_sample="3",type="summary"} \d*(?:.\d*)?
 summary_test{quantile="0.99",s_sample="1",s_subsample="b",type="summary"} \d*(?:.\d*)?
-summary_test{quantile="0.99",s_sample="1",type="summary"} \d*(?:.\d*)?
-summary_test{quantile="0.99",s_sample="2",type="summary"} \d*(?:.\d*)?
-summary_test{quantile="0.99",s_sample="3",type="summary"} \d*(?:.\d*)?
+summary_test_count{s_sample="1",s_subsample="b",type="summary"} \d*(?:.\d*)?
+summary_test_sum{s_sample="1",s_subsample="b",type="summary"} \d*(?:.\d*)?
 """
         f = TextFormatter()
         self.maxDiff = None
-        # Check multiple times to ensure multiple marshalling requests
+        # Check multiple times to ensure multiple calls to marshalling
+        # produce the same results
         for i in range(format_times):
             self.assertTrue(re.match(valid_regex, f.marshall(registry).decode()))

--- a/tests/test_metricdict.py
+++ b/tests/test_metricdict.py
@@ -7,7 +7,6 @@ from aioprometheus.metricdict import MetricDict
 
 
 class TestMetricDict(unittest.TestCase):
-
     def setUp(self):
         pass
 

--- a/tests/test_negotiate.py
+++ b/tests/test_negotiate.py
@@ -6,7 +6,6 @@ from aioprometheus.formats import TextFormatter, BinaryFormatter
 
 
 class TestNegotiate(unittest.TestCase):
-
     def test_protobuffer(self):
         """ check that a protobuf formatter is returned """
         headers = (

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -56,7 +56,6 @@ def expected_job_path(job):
 
 
 class TestPusher(asynctest.TestCase):
-
     async def setUp(self):
         self.server = TestPusherServer(loop=self.loop)
         await self.server.start()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,7 +4,6 @@ from aioprometheus import CollectorRegistry, Collector, Counter, Gauge, Summary
 
 
 class TestRegistry(unittest.TestCase):
-
     def setUp(self):
         self.data = {
             "name": "logged_users_total",


### PR DESCRIPTION
The changes in this merge request should fix #28.

- Fix histogram to produce the expected cumulative results.
- Fix histogram to sort metrics placing +Inf last followed by the count and then sum.
- For consistency by report histogram values as float
- Some cosmetic docs updates.
- Bump version in preparation for a new release.
- Style formatting fixes
