### PR TITLE
add metrics render function

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,7 @@ The example script can be run using:
 
     (venv) $ cd examples
     (venv) $ python simple-example.py
-    Serving prometheus metrics on: http://127.0.0.1:50624/metrics
+    Serving prometheus metrics on: http://127.0.0.1:5000/metrics
 
 In another terminal fetch the metrics using the ``curl`` command line tool
 to verify they can be retrieved by Prometheus server.
@@ -73,12 +73,12 @@ By default metrics will be returned in plan text format.
 
 .. code-block:: console
 
-    $ curl http://127.0.0.1:50624/metrics
+    $ curl http://127.0.0.1:5000/metrics
     # HELP events Number of events.
     # TYPE events counter
     events{host="alpha",kind="timer_expiry"} 33
 
-    $ curl http://127.0.0.1:50624/metrics -H 'Accept: text/plain; version=0.0.4'
+    $ curl http://127.0.0.1:5000/metrics -H 'Accept: text/plain; version=0.0.4'
     # HELP events Number of events.
     # TYPE events counter
     events{host="alpha",kind="timer_expiry"} 36
@@ -88,7 +88,7 @@ to read on the command line.
 
 .. code-block:: console
 
-    $ curl http://127.0.0.1:50624/metrics -H "ACCEPT: application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited"
+    $ curl http://127.0.0.1:5000/metrics -H "ACCEPT: application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited"
 
 The metrics service also responds to requests sent to its ``/`` route. The
 response is simple HTML. This route can be useful as a Kubernetes health
@@ -97,15 +97,24 @@ serialize a full metrics response.
 
 .. code-block:: console
 
-    $ curl http://127.0.0.1:50624/
+    $ curl http://127.0.0.1:5000/
     <html><body><a href='/metrics'>metrics</a></body></html>
 
-A number of convenience decorator functions are also available to assist with
-updating metrics.
+The aioprometheus package provides a number of convenience decorator
+functions that can assist with updating metrics.
 
-There are more examples in the ``examples`` directory. The ``app-example.py``
-file will likely be of interest as it provides a more representative
-application example.
+There ``examples`` directory contains many examples showing how to use the
+aioprometheus package. The ``app-example.py`` file will likely be of interest
+as it provides a more representative application example that the simple
+example shown above.
+
+Examples in the ``examples/frameworks`` directory show how aioprometheus can
+be used within existing aiohttp, quart and vibora applications instead of
+creating a separate aioprometheus.Service endpoint to handle metrics. The
+vibora example is shown below.
+
+.. literalinclude:: ../examples/frameworks/vibora-example.py
+    :language: python3
 
 
 License

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -222,7 +222,7 @@ The example script can be run using:
 
     (venv) $ cd examples
     (venv) $ python simple-example.py
-    Serving prometheus metrics on: http://127.0.0.1:50624/metrics
+    Serving prometheus metrics on: http://127.0.0.1:5000/metrics
 
 In another terminal fetch the metrics using the ``curl`` command line tool
 to verify they can be retrieved by Prometheus server.
@@ -231,12 +231,12 @@ By default metrics will be returned in plan text format.
 
 .. code-block:: console
 
-    $ curl http://127.0.0.1:50624/metrics
+    $ curl http://127.0.0.1:5000/metrics
     # HELP events Number of events.
     # TYPE events counter
     events{host="alpha",kind="timer_expiry"} 33
 
-    $ curl http://127.0.0.1:50624/metrics -H 'Accept: text/plain; version=0.0.4'
+    $ curl http://127.0.0.1:5000/metrics -H 'Accept: text/plain; version=0.0.4'
     # HELP events Number of events.
     # TYPE events counter
     events{host="alpha",kind="timer_expiry"} 36
@@ -246,7 +246,7 @@ to read on the command line.
 
 .. code-block:: console
 
-    $ curl http://127.0.0.1:50624/metrics -H "ACCEPT: application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited"
+    $ curl http://127.0.0.1:5000/metrics -H "ACCEPT: application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited"
 
 The metrics service also responds to requests sent to its ``/`` route. The
 response is simple HTML. This route can be useful as a Kubernetes ``/healthz``
@@ -255,7 +255,7 @@ to serialize a full metrics response.
 
 .. code-block:: console
 
-    $ curl http://127.0.0.1:50624/
+    $ curl http://127.0.0.1:5000/
     <html><body><a href='/metrics'>metrics</a></body></html>
 
 
@@ -274,10 +274,21 @@ The example can be run using
 .. code-block:: console
 
     (env) $ python app-example.py
-    Serving prometheus metrics on: http://127.0.0.1:50624/metrics
+    Serving prometheus metrics on: http://127.0.0.1:5000/metrics
 
 You can use the ``curl`` command line tool to fetch metrics manually or use
 the helper script described in the next section.
+
+Frameworks Example
+++++++++++++++++++
+
+The aioprometheus package can also be used within other web framework based
+applications such as ``aiohttp``, ``quart`` and ``vibora`` applications.
+This usage approach removes the need to create a separate server endpoint
+to handle metrics. The vibora example is shown below.
+
+.. literalinclude:: ../../examples/frameworks/vibora-example.py
+    :language: python3
 
 
 Checking examples using helper script
@@ -307,7 +318,7 @@ Example:
 
 .. code-block:: console
 
-    $ python metrics-fetcher.py --url=http://127.0.0.1:50624/metrics --format=text --interval=2.0
+    $ python metrics-fetcher.py --url=http://127.0.0.1:5000/metrics --format=text --interval=2.0
 
 
 Checking Example using Prometheus
@@ -334,7 +345,7 @@ we can create a minimal configuration file to scrape the example application.
         scrape_timeout: 10s
 
         target_groups:
-          - targets: ['localhost:50624']
+          - targets: ['localhost:5000']
             labels:
               group: 'dev'
 

--- a/examples/app-example.py
+++ b/examples/app-example.py
@@ -22,13 +22,25 @@ from asyncio.base_events import BaseEventLoop
 class ExampleApp(object):
     """
     An example application that demonstrates how ``aioprometheus`` can be
-    used within a Python async application.
+    integrated and used within a Python application built upon asyncio.
+
+    This application attempts to simulate a long running distributed system
+    process, say a socket relay or some kind of message adapter. It is
+    intentionally not hosting an existing web service in the application.
+
+    In this case the aioprometheus.Service object is used to provide a
+    new HTTP endpoint that can be used to expose Prometheus metrics on.
+
+    If this application was a web service (i.e. already had an existing web
+    interface) then the aioprometheus.Service object could be used as before
+    to add another web interface or a different approach could be used that
+    provides a metrics handler function for use with the existing web service.
     """
 
     def __init__(
         self,
         metrics_host="127.0.0.1",
-        metrics_port: int = 0,
+        metrics_port: int = 5000,
         loop: BaseEventLoop = None,
     ):
 

--- a/examples/frameworks/aiohttp-example.py
+++ b/examples/frameworks/aiohttp-example.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""
+Sometimes you want to expose Prometheus metrics from within an existing web
+service and don't want to start a separate Prometheus metrics server.
+
+This example uses the aioprometheus package to add Prometheus instrumentation
+to an aiohttp application. In this example a registry and a counter metric is
+instantiated. A '/metrics' route is added to the application and the render
+function from aioprometheus is called to format the metrics into the
+appropriate format.
+"""
+
+from aiohttp import web
+from aiohttp.hdrs import ACCEPT
+from aioprometheus import render, Counter, Registry
+
+
+app = web.Application()
+app.registry = Registry()
+app.events_counter = Counter("events", "Number of events.")
+app.registry.register(app.events_counter)
+
+
+async def handle_root(request):
+    app.events_counter.inc({"path": "/"})
+    text = "Hello aiohttp"
+    return web.Response(text=text)
+
+
+async def handle_metrics(request):
+    content, http_headers = render(app.registry, request.headers.getall(ACCEPT, []))
+    return web.Response(body=content, headers=http_headers)
+
+
+app.add_routes([web.get("/", handle_root), web.get("/metrics", handle_metrics)])
+
+
+web.run_app(app)

--- a/examples/frameworks/quart-example.py
+++ b/examples/frameworks/quart-example.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""
+Sometimes you want to expose Prometheus metrics from within an existing web
+service and don't want to start a separate Prometheus metrics server.
+
+This example uses the aioprometheus package to add Prometheus instrumentation
+to a Quart application. In this example a registry and a counter metric is
+instantiated. A '/metrics' route is added to the application and the render
+function from aioprometheus is called to format the metrics into the
+appropriate format.
+"""
+
+from aioprometheus import render, Counter, Registry
+from quart import Quart, request
+
+
+app = Quart(__name__)
+app.registry = Registry()
+app.events_counter = Counter("events", "Number of events.")
+app.registry.register(app.events_counter)
+
+
+@app.route("/")
+async def hello():
+    app.events_counter.inc({"path": "/"})
+    return "hello"
+
+
+@app.route("/metrics")
+async def handle_metrics():
+    content, http_headers = render(app.registry, request.headers.getlist("accept"))
+    return content, http_headers
+
+
+app.run()

--- a/examples/frameworks/vibora-example.py
+++ b/examples/frameworks/vibora-example.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""
+Sometimes you want to expose Prometheus metrics from within an existing web
+service and don't want to start a separate Prometheus metrics server.
+
+This example uses the aioprometheus package to add Prometheus instrumentation
+to a Vibora application. In this example a registry and a counter metric is
+instantiated. A '/metrics' route is added to the application and the render
+function from aioprometheus is called to format the metrics into the
+appropriate format.
+"""
+
+from aioprometheus import render, Counter, Registry
+from vibora import Vibora, Request, Response
+
+
+app = Vibora(__name__)
+app.registry = Registry()
+app.events_counter = Counter("events", "Number of events.")
+app.registry.register(app.events_counter)
+
+
+@app.route("/")
+async def hello(request: Request):
+    app.events_counter.inc({"path": "/"})
+    return Response(b"hello")
+
+
+@app.route("/metrics")
+async def handle_metrics(request: Request):
+    """
+    Negotiate a response format by inspecting the ACCEPTS headers and selecting
+    the most efficient format. Render metrics in the registry into the chosen
+    format and return a response.
+    """
+    content, http_headers = render(app.registry, [request.headers.get("accept")])
+    return Response(content, headers=http_headers)
+
+
+app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp >= 3.2.1
+aiohttp >= 3.3.2
 asynctest
 prometheus-metrics-proto >= 18.1.1
 quantile-python >= 1.1

--- a/src/aioprometheus/__init__.py
+++ b/src/aioprometheus/__init__.py
@@ -3,9 +3,10 @@ from .collectors import Collector, Counter, Gauge, Summary, Histogram
 from .decorators import count_exceptions, inprogress, timer
 from . import formats
 from . import pusher
-from . import negotiator
+from .negotiator import negotiate
 from .registry import Registry, CollectorRegistry
 from .service import Service
+from .renderer import render
 
 
-__version__ = "18.01.04"
+__version__ = "18.7.1"

--- a/src/aioprometheus/formats/__init__.py
+++ b/src/aioprometheus/formats/__init__.py
@@ -1,3 +1,3 @@
 from .base import IFormatter
-from .text import TextFormatter, TEXT_CONTENT_TYPE
-from .binary import BinaryFormatter, BINARY_CONTENT_TYPE
+from .text import TextFormatter, TEXT_CONTENT_TYPE, TEXT_ACCEPTS
+from .binary import BinaryFormatter, BINARY_CONTENT_TYPE, BINARY_ACCEPTS

--- a/src/aioprometheus/formats/binary.py
+++ b/src/aioprometheus/formats/binary.py
@@ -30,6 +30,7 @@ BINARY_CONTENT_TYPE = (
     "proto=io.prometheus.client.MetricFamily; "
     "encoding=delimited"
 )
+BINARY_ACCEPTS = set(BINARY_CONTENT_TYPE.split("; "))
 
 
 class BinaryFormatter(IFormatter):

--- a/src/aioprometheus/formats/text.py
+++ b/src/aioprometheus/formats/text.py
@@ -35,6 +35,7 @@ NEG_INF = float("-inf")
 
 
 TEXT_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+TEXT_ACCEPTS = set(TEXT_CONTENT_TYPE.split("; "))
 
 
 class TextFormatter(IFormatter):

--- a/src/aioprometheus/renderer.py
+++ b/src/aioprometheus/renderer.py
@@ -1,0 +1,37 @@
+
+from .formats import TextFormatter, BinaryFormatter
+from .registry import Registry
+from .negotiator import negotiate
+from typing import Sequence, Tuple, Union
+
+
+def render(registry: Registry, accepts_headers: Sequence[str]) -> Tuple[bytes, dict]:
+    """ Render the metrics in this registry to a specific format.
+
+    The format chosen is determined by scanning through the ACCEPTS headers
+    and selecting the most efficient format. If no accepts headers
+    information is provided then Text format is used as the default.
+
+    :param registry: A collector registry that contains the metrics to be
+      rendered into a specific format.
+
+    :param accepts_headers: a list of ACCEPT headers fields extracted from a request.
+
+    :returns: a 2-tuple where the first item is a bytes object that
+        represents the formatted metrics and the second item is a dict of
+        header fields that can be added to a HTTP response.
+    """
+    if not isinstance(registry, Registry):
+        raise Exception(f"registry must be a Registry, got: {type(registry)}")
+
+    if not isinstance(accepts_headers, (set, list, tuple)):
+        raise Exception(
+            f"accepts_headers must be a sequence, got: {type(accepts_headers)}"
+        )
+
+    Formatter = negotiate(accepts_headers)
+    formatter = Formatter()  # type: Union[TextFormatter, BinaryFormatter]
+
+    http_headers = formatter.get_headers()
+    content = formatter.marshall(registry)
+    return content, http_headers

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1,0 +1,91 @@
+import asynctest
+import aiohttp
+import aiohttp.hdrs
+import aiohttp.web
+import unittest
+import aioprometheus
+
+
+class TestAiohttpRender(asynctest.TestCase):
+    """
+    Test exposing Prometheus metrics from within a aiohttp existing web
+    service without starting a separate Prometheus metrics server.
+    """
+
+    async def test_render_in_aiohttp_app(self):
+        """ check render usage in aiohttp app """
+
+        app = aiohttp.web.Application()
+        app.registry = aioprometheus.Registry()
+        app.events_counter = aioprometheus.Counter("events", "Number of events.")
+        app.registry.register(app.events_counter)
+
+        async def index(request):
+            app.events_counter.inc({"path": "/"})
+            return aiohttp.web.Response(text="hello")
+
+        async def handle_metrics(request):
+            content, http_headers = aioprometheus.render(
+                app.registry, request.headers.getall(aiohttp.hdrs.ACCEPT, [])
+            )
+            return aiohttp.web.Response(body=content, headers=http_headers)
+
+        app.add_routes(
+            [aiohttp.web.get("/", index), aiohttp.web.get("/metrics", handle_metrics)]
+        )
+
+        runner = aiohttp.web.AppRunner(app)
+        await runner.setup()
+
+        site = aiohttp.web.TCPSite(runner, "127.0.0.1", 0, shutdown_timeout=1.0)
+        await site.start()
+
+        # Fetch ephemeral port that was bound.
+        # IPv4 address returns a 2-tuple, IPv6 returns a 4-tuple
+        host, port, *_ = runner.addresses[0]
+        host = host if ":" not in host else f"[{host}]"
+        url = f"http://{host}:{port}"
+        root_url = f"{url}/"
+        metrics_url = f"{url}/metrics"
+
+        async with aiohttp.ClientSession() as session:
+
+            # Access root to increment metric counter
+            async with session.get(root_url) as response:
+                self.assertEqual(response.status, 200)
+
+            # Get default format
+            async with session.get(
+                metrics_url, headers={aiohttp.hdrs.ACCEPT: "*/*"}
+            ) as response:
+                self.assertEqual(response.status, 200)
+                self.assertIn(
+                    aioprometheus.formats.TEXT_CONTENT_TYPE,
+                    response.headers.get("content-type"),
+                )
+                # content = await response.read()
+
+            # Get text format
+            async with session.get(
+                metrics_url, headers={aiohttp.hdrs.ACCEPT: "text/plain;"}
+            ) as response:
+                self.assertEqual(response.status, 200)
+                self.assertIn(
+                    aioprometheus.formats.TEXT_CONTENT_TYPE,
+                    response.headers.get("content-type"),
+                )
+
+            # Get binary format
+            async with session.get(
+                metrics_url,
+                headers={
+                    aiohttp.hdrs.ACCEPT: aioprometheus.formats.BINARY_CONTENT_TYPE
+                },
+            ) as response:
+                self.assertEqual(response.status, 200)
+                self.assertIn(
+                    aioprometheus.formats.BINARY_CONTENT_TYPE,
+                    response.headers.get("content-type"),
+                )
+
+        await runner.cleanup()

--- a/tests/test_quart.py
+++ b/tests/test_quart.py
@@ -1,0 +1,72 @@
+import asynctest
+import unittest
+import aioprometheus
+
+try:
+    from quart import Quart, request
+
+    have_quart = True
+except ImportError:
+    have_quart = False
+
+
+@unittest.skipUnless(have_quart, "Quart library is not available")
+class TestQuartRender(asynctest.TestCase):
+    """
+    Test exposing Prometheus metrics from within an Quart existing web
+    service without starting a separate Prometheus metrics server.
+    """
+
+    async def test_render_in_quart_app(self):
+        """ check render usage in Quart app """
+
+        app = Quart(__name__)
+        app.registry = aioprometheus.Registry()
+        app.events_counter = aioprometheus.Counter("events", "Number of events.")
+        app.registry.register(app.events_counter)
+
+        @app.route("/")
+        async def index():
+            app.events_counter.inc({"path": "/"})
+            return "hello"
+
+        @app.route("/metrics")
+        async def handle_metrics():
+            content, http_headers = aioprometheus.render(
+                app.registry, request.headers.getlist("accept")
+            )
+            return content, http_headers
+
+        # The test client also starts the web service
+        test_client = app.test_client()
+
+        # Access root to increment metric counter
+        response = await test_client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+        # Get default format
+        response = await test_client.get("/metrics", headers={"accept": "*/*"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            aioprometheus.formats.TEXT_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )
+        # payload = await response.get_data()
+
+        # Get text format
+        response = await test_client.get("/metrics", headers={"accept": "text/plain;"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            aioprometheus.formats.TEXT_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )
+
+        # Get binary format
+        response = await test_client.get(
+            "/metrics", headers={"accept": aioprometheus.formats.BINARY_CONTENT_TYPE}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            aioprometheus.formats.BINARY_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,46 @@
+import asynctest
+import aioprometheus
+
+
+class TestRenderer(asynctest.TestCase):
+    async def test_invalid_registry(self):
+        """ check only valid registry can be provided """
+        for invalid_registry in ["nope", dict(), list()]:
+            with self.assertRaises(Exception) as cm:
+                aioprometheus.render(invalid_registry, [])
+            self.assertIn("registry must be a Registry, got:", str(cm.exception))
+
+    async def test_invalid_accepts_headers(self):
+        """ check only valid accepts_headers types can be provided """
+        registry = aioprometheus.Registry()
+        for accepts_headers in ["nope", None, 42, dict()]:
+            with self.assertRaises(Exception) as cm:
+                aioprometheus.render(registry, accepts_headers)
+            self.assertIn("accepts_headers must be a sequence, got:", str(cm.exception))
+
+    async def test_render_default(self):
+        """ check metrics can be rendered using default format """
+        accepts_headers = ("application/json", "*/*", "application/nothing")
+        registry = aioprometheus.Registry()
+        content, http_headers = aioprometheus.render(registry, accepts_headers)
+        self.assertEqual(
+            http_headers["Content-Type"], aioprometheus.formats.TEXT_CONTENT_TYPE
+        )
+
+    async def test_render_text(self):
+        """ check metrics can be rendered using text format """
+        accepts_headers = ("text/plain;",)
+        registry = aioprometheus.Registry()
+        content, http_headers = aioprometheus.render(registry, accepts_headers)
+        self.assertEqual(
+            http_headers["Content-Type"], aioprometheus.formats.TEXT_CONTENT_TYPE
+        )
+
+    async def test_render_binary(self):
+        """ check metrics can be rendered using binary format """
+        accepts_headers = (aioprometheus.formats.BINARY_CONTENT_TYPE,)
+        registry = aioprometheus.Registry()
+        content, http_headers = aioprometheus.render(registry, accepts_headers)
+        self.assertEqual(
+            http_headers["Content-Type"], aioprometheus.formats.BINARY_CONTENT_TYPE
+        )

--- a/tests/test_vibora.py
+++ b/tests/test_vibora.py
@@ -1,0 +1,81 @@
+import asynctest
+import unittest
+import aioprometheus
+
+try:
+    from vibora import Vibora, Request, Response
+
+    have_vibora = True
+except ImportError:
+    have_vibora = False
+
+
+@unittest.skipUnless(have_vibora, "Vibora library is not available")
+class TestViboraRender(asynctest.TestCase):
+    """
+    Test exposing Prometheus metrics from within an Vibora existing web
+    service without starting a separate Prometheus metrics server.
+    """
+
+    async def test_render_in_vibora_app(self):
+        """ check render usage in Vibora app """
+
+        app = Vibora(__name__)
+        app.registry = aioprometheus.Registry()
+        app.events_counter = aioprometheus.Counter("events", "Number of events.")
+        app.registry.register(app.events_counter)
+
+        @app.route("/")
+        async def index(request: Request):
+            app.events_counter.inc({"path": "/"})
+            return Response(b"hello")
+
+        @app.route("/metrics")
+        async def handle_metrics(request: Request):
+            """
+            Negotiate a response format by inspecting the ACCEPTS headers and selecting
+            the most efficient format. Render metrics in the registry into the chosen
+            format and return a response.
+            """
+            content, http_headers = aioprometheus.render(
+                app.registry, [request.headers.get("accept")]
+            )
+            return Response(content, headers=http_headers)
+
+        # NOTE: Vibora client.get HTTP headers handling seem to expect case-sensitive.
+        # Must use Accept and not accept or ACCEPT! Where as response handling of
+        # requests doesn't seem to care.
+        # Until Vibora #139 is resolved we must use "Accept".
+
+        # The test client also starts the web service
+        client = app.test_client()
+
+        # Access root to increment metric counter
+        response = await client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+        # Get default format
+        response = await client.get("/metrics", headers={"Accept": "*/*"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            aioprometheus.formats.TEXT_CONTENT_TYPE,
+            [response.headers.get("Content-Type")],
+        )
+
+        # Get text format
+        response = await client.get("/metrics", headers={"Accept": "text/plain;"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            aioprometheus.formats.TEXT_CONTENT_TYPE,
+            [response.headers.get("content-type")],
+        )
+
+        # # Get binary format
+        response = await client.get(
+            "/metrics", headers={"Accept": aioprometheus.formats.BINARY_CONTENT_TYPE}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            aioprometheus.formats.BINARY_CONTENT_TYPE,
+            [response.headers.get("content-type")],
+        )


### PR DESCRIPTION
This merge request adds a metrics rendering function that makes it easier to use aioprometheus from within existing Python web framework applications, such as Vibora, Quart and aiohttp, where an existing web server is already available and there is no desire to start another server endpoint just to server Prometheus metrics. 

- The Service now makes use of the new render function.
- A test was added to check the render function.
- Tests are included that verify the render function operates as expected when used within various frameworks.
- Docs have been updated.
- Examples have been included which demonstrate how to use the render function within various frameworks.
- Some examples where updated to use a fixed port instead of an ephemeral one to simplify matching docs to example code output.
- The undocumented and untested discovery service feature was removed.
- The version has been bumped in preparation for a new release.
- The requirements have been updated as a recent feature from aiohttp 3.3.2 is now being used instead of accessing non-public internal attributes.

This resolves #27 