### PR TITLE
Update for next release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
+  - 3.8
+  - 3.7
   - 3.6
   - pypy3
 os:
@@ -13,7 +15,7 @@ install:
   - pip install dist/aioprometheus-*.whl
 script:
   - make test
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install black; make style; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install black; make check-style; fi
 matrix:
   allow_failures:
     - python: pypy3

--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,16 @@ coverage:
 	@cd docs/coverage; mv index.html coverage.html
 
 
-# help: style                          - perform code format compliance check
+# help: style                          - perform code style format
 .PHONY: style
 style:
 	@black src/aioprometheus tests examples
+
+
+# help: check-style                    - check code format compliance
+.PHONY: check-style
+check-style:
+	@black --check src/aioprometheus tests examples
 
 
 # help: check_types                    - check type hint annotations
@@ -92,7 +98,8 @@ docs.serve:
 
 # help: dist                           - create a wheel distribution package
 .PHONY: dist
-dist: clean
+dist:
+	@rm -rf dist
 	@python setup.py bdist_wheel
 
 

--- a/src/aioprometheus/__init__.py
+++ b/src/aioprometheus/__init__.py
@@ -1,4 +1,3 @@
-
 from .collectors import Collector, Counter, Gauge, Summary, Histogram
 from .decorators import count_exceptions, inprogress, timer
 from . import formats
@@ -9,4 +8,4 @@ from .service import Service
 from .renderer import render
 
 
-__version__ = "18.7.1"
+__version__ = "19.10.0"

--- a/src/aioprometheus/collectors.py
+++ b/src/aioprometheus/collectors.py
@@ -1,4 +1,3 @@
-
 import collections
 import enum
 import json

--- a/src/aioprometheus/formats/base.py
+++ b/src/aioprometheus/formats/base.py
@@ -1,4 +1,3 @@
-
 import abc
 import collections
 import datetime

--- a/src/aioprometheus/histogram.py
+++ b/src/aioprometheus/histogram.py
@@ -1,4 +1,3 @@
-
 from collections import OrderedDict
 from typing import Dict, List, Union
 

--- a/src/aioprometheus/negotiator.py
+++ b/src/aioprometheus/negotiator.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from . import formats

--- a/src/aioprometheus/pusher.py
+++ b/src/aioprometheus/pusher.py
@@ -1,4 +1,3 @@
-
 import asyncio
 
 import aiohttp

--- a/src/aioprometheus/registry.py
+++ b/src/aioprometheus/registry.py
@@ -1,4 +1,3 @@
-
 from .collectors import Collector, Counter, Gauge, Histogram, Summary
 from typing import Dict, List, Union
 

--- a/src/aioprometheus/renderer.py
+++ b/src/aioprometheus/renderer.py
@@ -1,4 +1,3 @@
-
 from .formats import TextFormatter, BinaryFormatter
 from .registry import Registry
 from .negotiator import negotiate

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,4 +1,3 @@
-
 import asynctest
 from aioprometheus import (
     Counter,

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,4 +1,3 @@
-
 import asynctest
 import aiohttp
 import unittest.mock

--- a/tests/test_metricdict.py
+++ b/tests/test_metricdict.py
@@ -1,4 +1,3 @@
-
 # copied from prometheus-python
 
 import unittest

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 from aioprometheus import Collector, Counter, Gauge, Histogram, Registry, Summary

--- a/tests/test_negotiate.py
+++ b/tests/test_negotiate.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 from aioprometheus.negotiator import negotiate

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -1,4 +1,3 @@
-
 import asynctest
 import asyncio
 


### PR DESCRIPTION
Prepare for a new package release containing changes from #33.

- Update version to 19.10.0
- Run style formatter (updated since last release which caused quite a few minor style updates).
- Add style check rule to Makefile.
- Call style check rule from ``.travis.yml`` file. The CI step will now properly fail if the code fails code format checks.
- Modify Makefile to not call the clean rule as part of generating a new distribution package. This causes venv performing the wheel generation to be deleted causing much sadness. 