### PR TITLE
Make aiohttp dependency optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,14 @@ Install
 
     $ pip install aioprometheus
 
+A Prometheus Push Gateway client and ASGI service are also provided, but the
+dependencies are not installed by default. You can install them alongside
+`aioprometheus` by running:
+
+.. code-block:: console
+
+    $ pip install aioprometheus[aiohttp]
+
 
 Example
 -------

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -48,10 +48,14 @@ To exit the virtual environment simply type ``deactivate``.
     The following steps assume you are operating in a virtual environment.
 
 
-Install Dependencies
---------------------
+Install Development Environment
+-------------------------------
 
 Install the developmental dependencies using ``pip``.
+
+This will install all normal dependencies of `aioprometheus` plus the `aiohttp`
+extra dependency. `aioprometheus` itself will be installed in a way that allows
+you to edit the code after it is installed so that any changes take effect immediately.
 
 .. code-block:: console
 
@@ -59,19 +63,7 @@ Install the developmental dependencies using ``pip``.
     $ pip install -r requirements.dev.txt
 
 Some rules in the convenience Makefile only work if the dependencies have been
-installed, such as **dist**, **style**, etc.
-
-
-Install aioprometheus
----------------------
-
-Use ``pip`` to perform a development install of `aioprometheus`. This installs
-the package in a way that allows you to edit the code after its installed so
-that any changes take effect immediately.
-
-.. code-block:: console
-
-    $ pip install -e .
+installed, such as **dist**, **style**, **test**, etc.
 
 
 Test

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+-e .[aiohttp]
 black
 sphinx
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-aiohttp >= 3.3.2
 asynctest
 prometheus-metrics-proto >= 18.1.1
 quantile-python >= 1.1

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ if __name__ == "__main__":
         package_dir={'': 'src'},
         packages=find_packages('src'),
         install_requires=requirements,
+        extras_require={
+            "aiohttp": ["aiohttp>=3.3.2"],
+        },
         classifiers=[
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",

--- a/src/aioprometheus/__init__.py
+++ b/src/aioprometheus/__init__.py
@@ -8,4 +8,4 @@ from .service import Service
 from .renderer import render
 
 
-__version__ = "19.10.0"
+__version__ = "19.11.0"

--- a/src/aioprometheus/pusher.py
+++ b/src/aioprometheus/pusher.py
@@ -1,7 +1,10 @@
 import asyncio
 
-import aiohttp
-import aiohttp.web
+try:
+    import aiohttp
+    import aiohttp.web
+except ImportError as err:
+    aiohttp = None
 
 from urllib.parse import urljoin
 from .formats import TextFormatter
@@ -32,6 +35,12 @@ class Pusher(object):
         :param loop: The event loop instance to use. If no loop is specified
           then the default event loop will be used.
         """
+        if aiohttp is None:
+            raise RuntimeError(
+                "`aiohttp` could not be imported. Did you install `aioprometheus` "
+                "with the `aiohttp` extra?"
+            )
+
         self.job_name = job_name
         self.addr = addr
         self.loop = loop or asyncio.get_event_loop()
@@ -39,7 +48,7 @@ class Pusher(object):
         self.headers = self.formatter.get_headers()
         self.path = urljoin(self.addr, self.PATH.format(job_name))
 
-    async def add(self, registry: CollectorRegistry) -> aiohttp.web.Response:
+    async def add(self, registry: CollectorRegistry) -> "aiohttp.web.Response":
         """
         ``add`` works like replace, but only metrics with the same name as the
         newly pushed metrics are replaced.
@@ -50,7 +59,7 @@ class Pusher(object):
         await resp.release()
         return resp
 
-    async def replace(self, registry: CollectorRegistry) -> aiohttp.web.Response:
+    async def replace(self, registry: CollectorRegistry) -> "aiohttp.web.Response":
         """
         ``replace`` pushes new values for a group of metrics to the push
         gateway.
@@ -67,7 +76,7 @@ class Pusher(object):
         await resp.release()
         return resp
 
-    async def delete(self, registry: CollectorRegistry) -> aiohttp.web.Response:
+    async def delete(self, registry: CollectorRegistry) -> "aiohttp.web.Response":
         """
         ``delete`` deletes metrics from the push gateway. All metrics with
         the grouping key specified in the URL are deleted.

--- a/src/aioprometheus/service.py
+++ b/src/aioprometheus/service.py
@@ -218,7 +218,9 @@ class Service(object):
             accepts.update(accept_items)
         return accepts
 
-    async def handle_root(self, request: "aiohttp.web.Request") -> "aiohttp.web.Response":
+    async def handle_root(
+        self, request: "aiohttp.web.Request"
+    ) -> "aiohttp.web.Response":
         """ Handle a request to the / route.
 
         Serves a trivial page with a link to the metrics.  Use this if ever
@@ -230,7 +232,9 @@ class Service(object):
             text=f"<html><body><a href='{metrics_url}'>metrics</a></body></html>",
         )
 
-    async def handle_robots(self, request: "aiohttp.web.Request") -> "aiohttp.web.Response":
+    async def handle_robots(
+        self, request: "aiohttp.web.Request"
+    ) -> "aiohttp.web.Response":
         """ Handle a request to /robots.txt
 
         If a robot ever stumbles on this server, discourage it from indexing.


### PR DESCRIPTION
Includes:
- Documentation update calling out the `aiohttp` extra for both the `Service` and `Pusher` features
- Import guards in `pusher` and `service`
- Runtime checks in the `Pusher` and `Service` initializers, to retain consistency in the top-level API
- Quoted type annotations where `aiohttp.web.*` might not be available
- Version bump to 19.11.0

---

@claws let me know if there is anything I missed or if you have any concerns, thanks! :)