### PR TITLE
Add import sorting to style compliance checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,23 @@ coverage:
 
 # help: style                          - perform code style format
 .PHONY: style
-style:
-	@black src/aioprometheus tests examples
+style: sort-imports format
 
 
 # help: check-style                    - check code format compliance
 .PHONY: check-style
-check-style:
+check-style: check-sort-imports check-format
+
+
+# help: format                          - perform code style format
+.PHONY: format
+format:
+	@black src/aioprometheus tests examples
+
+
+# help: check-format                    - check code format compliance
+.PHONY: check-format
+check-format:
 	@black --check src/aioprometheus tests examples
 
 
@@ -78,6 +88,18 @@ check-style:
 .PHONY: check_types
 check_types:
 	@cd src; MYPYPATH=$VIRTUAL_ENV/lib/python*/site-packages mypy -p aioprometheus --ignore-missing-imports
+
+
+# help: sort-imports                   - apply import sort ordering
+.PHONY: sort-imports
+sort-imports:
+	@isort . --profile black
+
+
+# help: check-sort-imports             - check imports are sorted
+.PHONY: check-sort-imports
+check-sort-imports:
+	@isort . --check-only --profile black
 
 
 # help: docs                           - generate project documentation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,9 @@
 import os
 import re
 import sys
+
 import alabaster
+
 sys.path.insert(0, os.path.abspath('..'))
 
 

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -68,8 +68,9 @@ code after it is installed so that any changes take effect immediately.
 Code Style
 ----------
 
-This project uses the Black code style formatter for consistent code style.
-A Makefile convenience rule is available to apply code style compliance.
+This project uses the Black code style formatter and isort to sort imports
+for consistent code style. A Makefile convenience rule is available to apply
+code style compliance.
 
 .. code-block:: console
 

--- a/examples/app-example.py
+++ b/examples/app-example.py
@@ -9,14 +9,14 @@ using ``pip install psutil``.
 
 import asyncio
 import logging
-import psutil
 import random
 import socket
 import uuid
+from asyncio.base_events import BaseEventLoop
+
+import psutil
 
 from aioprometheus import Counter, Gauge, Histogram, Service, Summary, formats
-
-from asyncio.base_events import BaseEventLoop
 
 
 class ExampleApp(object):

--- a/examples/decorator_count_exceptions.py
+++ b/examples/decorator_count_exceptions.py
@@ -21,8 +21,7 @@ You may need to Ctrl+C twice to exit the example script.
 import asyncio
 import random
 
-from aioprometheus import Service, Counter, count_exceptions
-
+from aioprometheus import Counter, Service, count_exceptions
 
 # Create a metric to track requests currently in progress.
 REQUESTS = Counter("request_handler_exceptions", "Number of exceptions in requests")

--- a/examples/decorator_inprogress.py
+++ b/examples/decorator_inprogress.py
@@ -19,8 +19,7 @@ The example script can be tested using ``curl``.
 import asyncio
 import random
 
-from aioprometheus import Service, Gauge, inprogress
-
+from aioprometheus import Gauge, Service, inprogress
 
 # Create a metric to track requests currently in progress.
 REQUESTS = Gauge("request_in_progress", "Number of requests in progress")

--- a/examples/decorator_timer.py
+++ b/examples/decorator_timer.py
@@ -26,7 +26,6 @@ import random
 
 from aioprometheus import Service, Summary, timer
 
-
 # Create a metric to track time spent and requests made.
 REQUEST_TIME = Summary("request_processing_seconds", "Time spent processing request")
 

--- a/examples/frameworks/aiohttp-example.py
+++ b/examples/frameworks/aiohttp-example.py
@@ -19,8 +19,8 @@ Run:
 
 from aiohttp import web
 from aiohttp.hdrs import ACCEPT
-from aioprometheus import render, Counter, Registry
 
+from aioprometheus import Counter, Registry, render
 
 app = web.Application()
 app.registry = Registry()

--- a/examples/frameworks/fastapi_example.py
+++ b/examples/frameworks/fastapi_example.py
@@ -17,10 +17,11 @@ Run:
 
 """
 
-from aioprometheus import render, Counter, Registry
-from fastapi import FastAPI, Header, Response
 from typing import List
 
+from fastapi import FastAPI, Header, Response
+
+from aioprometheus import Counter, Registry, render
 
 app = FastAPI()
 app.registry = Registry()

--- a/examples/frameworks/quart-example.py
+++ b/examples/frameworks/quart-example.py
@@ -17,9 +17,9 @@ Run:
 
 """
 
-from aioprometheus import render, Counter, Registry
 from quart import Quart, request
 
+from aioprometheus import Counter, Registry, render
 
 app = Quart(__name__)
 app.registry = Registry()

--- a/examples/metrics-fetcher.py
+++ b/examples/metrics-fetcher.py
@@ -12,16 +12,17 @@ Usage:
 
 """
 
-import aiohttp
-import aioprometheus
 import argparse
 import asyncio
 import logging
-import prometheus_metrics_proto
 import random
-from aiohttp.hdrs import ACCEPT, CONTENT_TYPE
 from asyncio.base_events import BaseEventLoop
 
+import aiohttp
+import prometheus_metrics_proto
+from aiohttp.hdrs import ACCEPT, CONTENT_TYPE
+
+import aioprometheus
 
 TEXT = "text"
 BINARY = "binary"
@@ -34,7 +35,7 @@ header_kinds = {
 async def fetch_metrics(
     url: str, fmt: str = None, interval: float = 1.0, loop: BaseEventLoop = None
 ):
-    """ Fetch metrics from the service endpoint using different formats.
+    """Fetch metrics from the service endpoint using different formats.
 
     This coroutine runs 'n' times, with a brief interval in between, before
     exiting.

--- a/examples/simple-example.py
+++ b/examples/simple-example.py
@@ -14,8 +14,8 @@ to verify they can be retrieved by Prometheus server.
 
 import asyncio
 import socket
-from aioprometheus import Counter, Service
 
+from aioprometheus import Counter, Service
 
 if __name__ == "__main__":
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,6 +3,7 @@ asynctest
 black
 sphinx
 coverage
+isort[requirements_deprecated_finder]
 mypy
 twine
 wheel

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@
 import os
 import re
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 regexp = re.compile(r'.*__version__ = [\'\"](.*?)[\'\"]', re.S)
 

--- a/src/aioprometheus/__init__.py
+++ b/src/aioprometheus/__init__.py
@@ -1,11 +1,9 @@
-from .collectors import Collector, Counter, Gauge, Summary, Histogram
+from . import formats, pusher
+from .collectors import Collector, Counter, Gauge, Histogram, Summary
 from .decorators import count_exceptions, inprogress, timer
-from . import formats
-from . import pusher
 from .negotiator import negotiate
-from .registry import Registry, CollectorRegistry
-from .service import Service
+from .registry import CollectorRegistry, Registry
 from .renderer import render
+from .service import Service
 
-
-__version__ = "20.0.1"
+__version__ = "20.0.2"

--- a/src/aioprometheus/collectors.py
+++ b/src/aioprometheus/collectors.py
@@ -2,12 +2,12 @@ import collections
 import enum
 import json
 import re
+from typing import Any, Dict, List, Sequence, Tuple, Union, cast
 
 import quantile
 
 from . import histogram
 from .metricdict import MetricDict
-from typing import cast, Any, Dict, List, Sequence, Tuple, Union
 
 # Used to return the value ordered (not necessary but for consistency useful)
 # type annotations are not correct for this package yet.
@@ -37,7 +37,7 @@ class MetricsTypes(enum.Enum):
 
 
 class Collector(object):
-    """ Base class for all collectors.
+    """Base class for all collectors.
 
     **Metric names and labels**
 
@@ -104,14 +104,14 @@ class Collector(object):
         self.values[labels] = value
 
     def get_value(self, labels: LabelsType) -> NumericValueType:
-        """  Gets a value in the container.
+        """Gets a value in the container.
 
         :raises: KeyError if an item with matching labels is not present.
         """
         return self.values[labels]
 
     def get(self, labels: LabelsType) -> NumericValueType:
-        """ Gets a value in the container.
+        """Gets a value in the container.
 
         Handy alias for `get_value`.
 
@@ -120,7 +120,7 @@ class Collector(object):
         return self.get_value(labels)
 
     def _label_names_correct(self, labels: LabelsType) -> bool:
-        """ Check validity of label names.
+        """Check validity of label names.
 
         :raises: ValueError if labels are invalid
         """
@@ -185,7 +185,7 @@ class Counter(Collector):
     kind = MetricsTypes.counter
 
     def get(self, labels: LabelsType) -> NumericValueType:
-        """ Get the Counter value matching an arbitrary group of labels.
+        """Get the Counter value matching an arbitrary group of labels.
 
         :raises: KeyError if an item with matching labels is not present.
         """
@@ -200,7 +200,7 @@ class Counter(Collector):
         self.add(labels, 1)
 
     def add(self, labels: LabelsType, value: NumericValueType) -> None:
-        """ Add the given value to the counter.
+        """Add the given value to the counter.
 
         :raises: ValueError if the value is negative. Counters can only
           increase.
@@ -242,7 +242,7 @@ class Gauge(Collector):
         self.set_value(labels, value)
 
     def get(self, labels: LabelsType) -> NumericValueType:
-        """ Get the gauge value matching an arbitrary group of labels.
+        """Get the gauge value matching an arbitrary group of labels.
 
         :raises: KeyError if an item with matching labels is not present.
         """
@@ -257,7 +257,7 @@ class Gauge(Collector):
         self.add(labels, -1)
 
     def add(self, labels: LabelsType, value: NumericValueType) -> None:
-        """ Add the given value to the Gauge.
+        """Add the given value to the Gauge.
 
         The value can be negative, resulting in a decrease of the gauge.
         """
@@ -274,7 +274,7 @@ class Gauge(Collector):
         self.set_value(labels, current + value)
 
     def sub(self, labels: LabelsType, value: NumericValueType) -> None:
-        """ Subtract the given value from the Gauge.
+        """Subtract the given value from the Gauge.
 
         The value can be negative, resulting in an increase of the gauge.
         """

--- a/src/aioprometheus/decorators.py
+++ b/src/aioprometheus/decorators.py
@@ -4,10 +4,10 @@ This module provides some convenience decorators for metrics
 
 import asyncio
 import time
-
-from .collectors import Counter, Gauge, Summary
 from functools import wraps
 from typing import Any, Callable, Dict
+
+from .collectors import Counter, Gauge, Summary
 
 
 def timer(metric: Summary, labels: Dict[str, str] = None) -> Callable[..., Any]:

--- a/src/aioprometheus/formats/__init__.py
+++ b/src/aioprometheus/formats/__init__.py
@@ -1,5 +1,5 @@
-from .base import IFormatter
 from . import text
+from .base import IFormatter
 
 try:
     from . import binary

--- a/src/aioprometheus/formats/base.py
+++ b/src/aioprometheus/formats/base.py
@@ -1,7 +1,6 @@
 import abc
 import collections
 import datetime
-
 from typing import Dict
 
 # typing aliases
@@ -67,7 +66,7 @@ class IFormatter(abc.ABC):
 
     @abc.abstractmethod
     def marshall(self, registry) -> bytes:
-        """ Marshalls a registry (containing many collectors) into a
+        """Marshalls a registry (containing many collectors) into a
         specific format.
 
         :returns: bytes

--- a/src/aioprometheus/formats/binary.py
+++ b/src/aioprometheus/formats/binary.py
@@ -3,14 +3,15 @@ This module implements a formatter that emits metrics in a binary (Google
 Protocol Buffers) format.
 """
 
-import prometheus_metrics_proto as pmp
+from typing import Callable, Dict, List, Tuple, Union, cast
 
-from .base import IFormatter
-from ..collectors import Counter, Gauge, Summary, Histogram
-from typing import cast, Callable, Dict, List, Tuple, Union
+import prometheus_metrics_proto as pmp
 
 # imports only used for type annotations
 from aioprometheus.registry import CollectorRegistry
+
+from ..collectors import Counter, Gauge, Histogram, Summary
+from .base import IFormatter
 
 # typing aliases
 LabelsType = Dict[str, str]
@@ -50,7 +51,7 @@ class BinaryFormatter(IFormatter):
     def _format_counter(
         self, counter: MetricTupleType, name: str, const_labels: LabelsType
     ) -> pmp.Metric:
-        """ Create a Counter metric instance.
+        """Create a Counter metric instance.
 
         :param counter: a 2-tuple containing labels and the counter value.
         :param name: the metric name.
@@ -72,7 +73,7 @@ class BinaryFormatter(IFormatter):
     def _format_gauge(
         self, gauge: MetricTupleType, name: str, const_labels: LabelsType
     ) -> pmp.Metric:
-        """ Create a Gauge metric instance.
+        """Create a Gauge metric instance.
 
         :param gauge: a 2-tuple containing labels and the gauge value.
         :param name: the metric name.
@@ -94,7 +95,7 @@ class BinaryFormatter(IFormatter):
     def _format_summary(
         self, summary: MetricTupleType, name: str, const_labels: LabelsType
     ) -> pmp.Metric:
-        """ Create a Summary metric instance.
+        """Create a Summary metric instance.
 
         :param summary: a 2-tuple containing labels and a dict representing
           the summary value. The dict contains keys for each quantile as
@@ -183,7 +184,7 @@ class BinaryFormatter(IFormatter):
         return mf
 
     def marshall(self, registry: CollectorRegistry) -> bytes:
-        """ Marshall the collectors in the registry into binary protocol
+        """Marshall the collectors in the registry into binary protocol
         buffer format.
 
         The Prometheus metrics parser expects each metric (MetricFamily) to

--- a/src/aioprometheus/formats/text.py
+++ b/src/aioprometheus/formats/text.py
@@ -1,13 +1,13 @@
 """ This module implements a Prometheus metrics text formatter """
 
 import collections
+from typing import Callable, Dict, List, Tuple, Union, cast
 
-from .base import IFormatter
-from ..collectors import Counter, Gauge, Summary, Histogram
-from typing import cast, Callable, Dict, List, Tuple, Union
+from ..collectors import Counter, Gauge, Histogram, Summary
 
 # imports only used for type annotations
 from ..registry import CollectorRegistry
+from .base import IFormatter
 
 # typing aliases
 LabelsType = Dict[str, str]
@@ -39,7 +39,7 @@ TEXT_ACCEPTS = set(TEXT_CONTENT_TYPE.split("; "))
 
 
 class TextFormatter(IFormatter):
-    """ This formatter encodes into the Text format.
+    """This formatter encodes into the Text format.
 
     The histogram and summary types are difficult to represent in the text
     format. The following conventions apply:
@@ -62,7 +62,7 @@ class TextFormatter(IFormatter):
     """
 
     def __init__(self, timestamp: bool = False) -> None:
-        """ Initialise the text formatter.
+        """Initialise the text formatter.
 
         timestamp is a boolean, if you want timestamp in each metric.
         """
@@ -161,7 +161,7 @@ class TextFormatter(IFormatter):
     def _format_histogram(
         self, histogram: MetricTupleType, name: str, const_labels: LabelsType
     ) -> List[str]:
-        """ Format a histogram into the text format.
+        """Format a histogram into the text format.
 
         Buckets must be sorted and +Inf should be last.
 
@@ -243,8 +243,8 @@ class TextFormatter(IFormatter):
         return LINE_SEPARATOR_FMT.join(result)
 
     def marshall(self, registry: CollectorRegistry) -> bytes:
-        """ Marshalls a registry (containing collectors) into a bytes
-        object """
+        """Marshalls a registry (containing collectors) into a bytes
+        object"""
 
         blocks = []
         for i in registry.get_all():

--- a/src/aioprometheus/histogram.py
+++ b/src/aioprometheus/histogram.py
@@ -11,7 +11,7 @@ BucketType = float
 def linearBuckets(
     start: Union[float, int], width: Union[int, float], count: int
 ) -> List[BucketType]:
-    """ Returns buckets that are spaced linearly.
+    """Returns buckets that are spaced linearly.
 
     Returns ``count`` buckets, each ``width`` wide, where the lowest bucket
     has an upper bound of ``start``. There is no +Inf bucket is included in
@@ -27,7 +27,7 @@ def linearBuckets(
 def exponentialBuckets(
     start: Union[float, int], factor: Union[float, int], count: int
 ) -> List[BucketType]:
-    """ Returns buckets that are spaced exponentially.
+    """Returns buckets that are spaced exponentially.
 
     Returns ``count`` buckets, where the lowest bucket has an upper bound of
     ``start`` and each following bucket's upper bound is ``factor`` times the
@@ -72,7 +72,7 @@ class Histogram(object):
         self.sum = 0.0  # type: float
 
     def observe(self, value: Union[float, int]) -> None:
-        """ Observe the given amount.
+        """Observe the given amount.
 
         Observing a value into the histogram will cumulatively increment the
         count of observations for the buckets that the observed values falls

--- a/src/aioprometheus/negotiator.py
+++ b/src/aioprometheus/negotiator.py
@@ -1,8 +1,7 @@
 import logging
-
-from . import formats
 from typing import Callable, Sequence, Set
 
+from . import formats
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +10,7 @@ FormatterType = Callable[[bool], formats.IFormatter]
 
 
 def negotiate(accepts_headers: Sequence[str]) -> FormatterType:
-    """ Negotiate a response format by scanning through a list of ACCEPTS
+    """Negotiate a response format by scanning through a list of ACCEPTS
     headers and selecting the most efficient format.
 
     The formatter returned by this function is used to render a response.

--- a/src/aioprometheus/pusher.py
+++ b/src/aioprometheus/pusher.py
@@ -7,11 +7,12 @@ except ImportError as err:
     aiohttp = None
 
 import base64
-from urllib.parse import quote_plus, urljoin
-from .formats import text
 
 # imports only used for type annotations
 from asyncio.base_events import BaseEventLoop
+from urllib.parse import quote_plus, urljoin
+
+from .formats import text
 from .registry import CollectorRegistry
 
 

--- a/src/aioprometheus/registry.py
+++ b/src/aioprometheus/registry.py
@@ -1,11 +1,12 @@
-from .collectors import Collector, Counter, Gauge, Histogram, Summary
 from typing import Dict, List, Union
+
+from .collectors import Collector, Counter, Gauge, Histogram, Summary
 
 CollectorsType = Union[Counter, Gauge, Histogram, Summary]
 
 
 class CollectorRegistry(object):
-    """ This class implements the metrics collector registry.
+    """This class implements the metrics collector registry.
 
     Collectors in the registry must comply with the Collector interface
     which means that they inherit from the base Collector object and implement
@@ -17,7 +18,7 @@ class CollectorRegistry(object):
         self.collectors = {}  # type: Dict[str, CollectorsType]
 
     def register(self, collector: CollectorsType) -> None:
-        """ Register a collector.
+        """Register a collector.
 
         This will allow the collector metrics to be emitted.
 
@@ -39,7 +40,7 @@ class CollectorRegistry(object):
         self.collectors[collector.name] = collector
 
     def deregister(self, name: str) -> None:
-        """ Deregister a collector.
+        """Deregister a collector.
 
         This will stop the collector metrics from being emitted.
 
@@ -50,7 +51,7 @@ class CollectorRegistry(object):
         del self.collectors[name]
 
     def get(self, name: str) -> CollectorsType:
-        """ Get a collector by name.
+        """Get a collector by name.
 
         :param name: The name of the collector to fetch.
 

--- a/src/aioprometheus/renderer.py
+++ b/src/aioprometheus/renderer.py
@@ -1,11 +1,12 @@
-from .formats import IFormatter
-from .registry import Registry
-from .negotiator import negotiate
 from typing import Sequence, Tuple, Union
+
+from .formats import IFormatter
+from .negotiator import negotiate
+from .registry import Registry
 
 
 def render(registry: Registry, accepts_headers: Sequence[str]) -> Tuple[bytes, dict]:
-    """ Render the metrics in this registry to a specific format.
+    """Render the metrics in this registry to a specific format.
 
     The format chosen is determined by scanning through the ACCEPTS headers
     and selecting the most efficient format. If no accepts headers

--- a/src/aioprometheus/service.py
+++ b/src/aioprometheus/service.py
@@ -8,19 +8,18 @@ import logging
 try:
     import aiohttp
     import aiohttp.web
-
-    from aiohttp.hdrs import METH_GET as GET, ACCEPT
+    from aiohttp.hdrs import ACCEPT
+    from aiohttp.hdrs import METH_GET as GET
 except ImportError:
     aiohttp = None
-
-from .renderer import render
-from .registry import Registry, CollectorsType
-from typing import Optional, Set
 
 # imports only used for type annotations
 from asyncio.base_events import BaseEventLoop, Server
 from ssl import SSLContext
+from typing import Optional, Set
 
+from .registry import CollectorsType, Registry
+from .renderer import render
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,7 @@ class Service(object):
 
     @property
     def base_url(self) -> str:
-        """ Return the base service url
+        """Return the base service url
 
         :raises: Exception if the server has not been started.
 
@@ -87,7 +86,7 @@ class Service(object):
 
     @property
     def root_url(self) -> str:
-        """ Return the root service url
+        """Return the root service url
 
         :raises: Exception if the server has not been started.
 
@@ -97,7 +96,7 @@ class Service(object):
 
     @property
     def metrics_url(self) -> str:
-        """ Return the Prometheus metrics url
+        """Return the Prometheus metrics url
 
         :raises: Exception if the server has not been started.
 
@@ -112,7 +111,7 @@ class Service(object):
         ssl: SSLContext = None,
         metrics_url: str = DEFAULT_METRICS_PATH,
     ) -> None:
-        """ Start the prometheus metrics HTTP(S) server.
+        """Start the prometheus metrics HTTP(S) server.
 
         :param addr: the address to bind the server on. By default this is
           set to an empty string so that the service becomes available on
@@ -160,7 +159,7 @@ class Service(object):
         logger.debug("Prometheus metrics server started on %s", self.metrics_url)
 
     async def stop(self, wait_duration: float = 1.0) -> None:
-        """ Stop the prometheus metrics HTTP(S) server.
+        """Stop the prometheus metrics HTTP(S) server.
 
         :param wait_duration: the number of seconds to wait for connections to
           finish.
@@ -178,7 +177,7 @@ class Service(object):
         logger.debug("Prometheus metrics server stopped")
 
     def register(self, collector: CollectorsType) -> None:
-        """ Register a collector.
+        """Register a collector.
 
         :raises: TypeError if collector is not an instance of
           :class:`Collector`.
@@ -187,7 +186,7 @@ class Service(object):
         self.registry.register(collector)
 
     def deregister(self, name: str) -> None:
-        """ Deregister a collector.
+        """Deregister a collector.
 
         :param name: A collector name to deregister.
         """
@@ -196,7 +195,7 @@ class Service(object):
     async def handle_metrics(
         self, request: "aiohttp.web.Request"
     ) -> "aiohttp.web.Response":
-        """ Handle a request to the metrics route.
+        """Handle a request to the metrics route.
 
         The request is inspected and the most efficient response data format
         is chosen.
@@ -221,7 +220,7 @@ class Service(object):
     async def handle_root(
         self, request: "aiohttp.web.Request"
     ) -> "aiohttp.web.Response":
-        """ Handle a request to the / route.
+        """Handle a request to the / route.
 
         Serves a trivial page with a link to the metrics.  Use this if ever
         you need to point a health check at your the service.
@@ -235,7 +234,7 @@ class Service(object):
     async def handle_robots(
         self, request: "aiohttp.web.Request"
     ) -> "aiohttp.web.Response":
-        """ Handle a request to /robots.txt
+        """Handle a request to /robots.txt
 
         If a robot ever stumbles on this server, discourage it from indexing.
         """

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1,8 +1,10 @@
-import asynctest
+import unittest
+
 import aiohttp
 import aiohttp.hdrs
 import aiohttp.web
-import unittest
+import asynctest
+
 import aioprometheus
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,12 +1,13 @@
 import asynctest
+
 from aioprometheus import (
     Counter,
     Gauge,
     Histogram,
     Summary,
-    timer,
-    inprogress,
     count_exceptions,
+    inprogress,
+    timer,
 )
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,13 +1,13 @@
-import asynctest
-import aiohttp
 import unittest.mock
-from aiohttp.hdrs import ACCEPT, CONTENT_TYPE
-import aioprometheus
+
+import aiohttp
+import asynctest
 import prometheus_metrics_proto as pmp
+from aiohttp.hdrs import ACCEPT, CONTENT_TYPE
 
+import aioprometheus
 from aioprometheus import Counter, Gauge, Histogram, Registry, Service, Summary
-from aioprometheus.formats import text, binary
-
+from aioprometheus.formats import binary, text
 
 TEXT = "text"
 BINARY = "binary"

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,6 +1,7 @@
 import unittest
-import aioprometheus
 from typing import List
+
+import aioprometheus
 
 try:
     from fastapi import FastAPI, Header, Response

--- a/tests/test_formats_binary.py
+++ b/tests/test_formats_binary.py
@@ -2,10 +2,11 @@ import datetime
 import time
 import unittest
 import unittest.mock
-import prometheus_metrics_proto as pmp
-from aioprometheus.formats import binary
-from aioprometheus import Collector, Counter, Gauge, Histogram, Summary, Registry
 
+import prometheus_metrics_proto as pmp
+
+from aioprometheus import Collector, Counter, Gauge, Histogram, Registry, Summary
+from aioprometheus.formats import binary
 
 TEST_TIMESTAMP = 1515044377268
 

--- a/tests/test_formats_text.py
+++ b/tests/test_formats_text.py
@@ -1,7 +1,7 @@
 import re
 import unittest
 
-from aioprometheus import Collector, Counter, Gauge, Histogram, Summary, Registry
+from aioprometheus import Collector, Counter, Gauge, Histogram, Registry, Summary
 from aioprometheus.formats import text
 
 

--- a/tests/test_negotiate.py
+++ b/tests/test_negotiate.py
@@ -1,7 +1,7 @@
 import unittest
 
+from aioprometheus.formats import binary, text
 from aioprometheus.negotiator import negotiate
-from aioprometheus.formats import text, binary
 
 
 class TestNegotiate(unittest.TestCase):

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -1,13 +1,13 @@
-import asynctest
 import asyncio
 
 import aiohttp
+import asynctest
 
-from aioprometheus import Counter, pusher, Registry
+from aioprometheus import Counter, Registry, pusher
 
 
 class TestPusherServer(object):
-    """ This fixture class acts as the Push Gateway.
+    """This fixture class acts as the Push Gateway.
 
     It handles requests and stores various request attributes in the
     test_results attribute which is later checked in tests.
@@ -77,7 +77,9 @@ class TestPusher(asynctest.TestCase):
         # for encoding rules.
         job_name = "my-job"
         p = pusher.Pusher(
-            job_name, self.server.url, grouping_key={"instance": "127.0.0.1:1234"},
+            job_name,
+            self.server.url,
+            grouping_key={"instance": "127.0.0.1:1234"},
         )
         registry = Registry()
         c = Counter("total_requests", "Total requests.", {})
@@ -99,7 +101,9 @@ class TestPusher(asynctest.TestCase):
         # for encoding rules.
         job_name = "example"
         p = pusher.Pusher(
-            job_name, self.server.url, grouping_key={"first": "", "second": "foo"},
+            job_name,
+            self.server.url,
+            grouping_key={"first": "", "second": "foo"},
         )
         registry = Registry()
         c = Counter("example_total", "Total examples", {})
@@ -120,7 +124,11 @@ class TestPusher(asynctest.TestCase):
         # See https://github.com/prometheus/pushgateway/blob/master/README.md#url
         # for encoding rules.
         job_name = "directory_cleaner"
-        p = pusher.Pusher(job_name, self.server.url, grouping_key={"path": "/var/tmp"},)
+        p = pusher.Pusher(
+            job_name,
+            self.server.url,
+            grouping_key={"path": "/var/tmp"},
+        )
         registry = Registry()
         c = Counter("exec_total", "Total executions", {})
         registry.register(c)

--- a/tests/test_quart.py
+++ b/tests/test_quart.py
@@ -1,5 +1,7 @@
-import asynctest
 import unittest
+
+import asynctest
+
 import aioprometheus
 
 try:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,6 @@
 import unittest
 
-from aioprometheus import CollectorRegistry, Collector, Counter, Gauge, Summary
+from aioprometheus import Collector, CollectorRegistry, Counter, Gauge, Summary
 
 
 class TestRegistry(unittest.TestCase):

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,4 +1,5 @@
 import asynctest
+
 import aioprometheus
 
 


### PR DESCRIPTION
This merge request adds import sorting to the code style compliance checks.

The ``isort`` package has been added as a developer dependency package.
The Makefile had been updated to add new rules. The ``style`` rule has been updated to perform both formatting and import sorting.

This merge request bumps the minor version simply to indicate a trivial change. No functionality is expected to change.