### PR TITLE
Add linting and type annotation checking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,22 @@ on:
 jobs:
   build:
 
+    name: "Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install wheel
         pip install -r requirements.dev.txt
         pip install -r requirements.txt
     - name: Cache pip dependencies
@@ -39,7 +41,7 @@ jobs:
         make check-style
     - name: Install package
       run: |
-        pip install .[aiohttp,binary]
+        pip install .[aiohttp,binary] --use-feature=in-tree-build
     - name: Run unit tests
       run: |
         make test

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,54 @@
+[MASTER]
+
+# Use multiple processes to speed up Pylint.
+jobs=4
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+
+[MESSAGES CONTROL]
+
+disable=invalid-name,
+        broad-except,
+        duplicate-code,
+        logging-fstring-interpolation,
+        missing-class-docstring,
+        missing-module-docstring,
+        missing-function-docstring,
+        no-self-use,
+        too-many-instance-attributes,
+        too-few-public-methods,
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[LOGGING]
+
+logging-format-style=new
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=160

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,9 @@ test.verbose:
 .PHONY: coverage
 coverage:
 	@coverage erase
-	@PYTHONPATH=src coverage run -m unittest discover -s tests -v
+	@rm -f .coverage.unit
+	@COVERAGE_FILE=.coverage.unit coverage run -m unittest discover -s tests -v
+	@coverage combine
 	@coverage html
 	@coverage report
 
@@ -84,10 +86,15 @@ check-format:
 	@black --check src/aioprometheus tests examples
 
 
-# help: check_types             - check type hint annotations
-.PHONY: check_types
-check_types:
-	@cd src; MYPYPATH=$VIRTUAL_ENV/lib/python*/site-packages mypy -p aioprometheus --ignore-missing-imports
+# help: check-lint              - check linting
+.PHONY: check-lint
+check-lint:
+	@pylint --rcfile=.pylintrc aioprometheus setup.py ./examples
+
+# help: check-types             - check type hint annotations
+.PHONY: check-types
+check-types:
+	@cd src; mypy -p aioprometheus --ignore-missing-imports
 
 
 # help: sort-imports            - apply import sort ordering
@@ -102,17 +109,17 @@ check-sort-imports:
 	@isort . --check-only --profile black
 
 
-# help: docs                    - generate project documentation
+# help: docs                    - generate HTML documentation
 .PHONY: docs
 docs: coverage
 	@cd docs; rm -rf api/aioprometheus*.rst api/modules.rst _build/*
 	@cd docs; make html
 
 
-# help: docs.serve              - serve HTML documentation
-.PHONY: docs.serve
-docs.serve:
-	@cd docs; python -m http.server
+# help: serve-docs              - serve HTML documentation
+.PHONY: serve-docs
+serve-docs:
+	@cd docs/_build/html; python -m http.server
 
 
 # help: dist                    - create a wheel distribution package
@@ -122,15 +129,15 @@ dist:
 	@python setup.py bdist_wheel
 
 
-# help: dist.test               - test a wheel distribution package
-.PHONY: dist.test
-dist.test: dist
+# help: test-dist               - test a wheel distribution package
+.PHONY: test-dist
+test-dist: dist
 	@cd dist && ../tests/test_dist.bash ./aioprometheus-*-py3-none-any.whl
 
 
-# help: dist.upload             - upload a wheel distribution package
-.PHONY: dist.upload
-dist.upload:
+# help: upload-dist             - upload package wheel distribution
+.PHONY: upload-dist
+upload-dist:
 	@twine upload dist/aioprometheus-*-py3-none-any.whl
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ with open(init_file, 'r') as f:
         version = match.group(1)
     else:
         raise RuntimeError(
-            'Cannot find __version__ in {}'.format(init_file))
+            f"Cannot find __version__ in {init_file}")
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -2,7 +2,7 @@ Developers Guide
 ================
 
 The project is hosted on `GitHub <https://github.com/claws/aioprometheus>`_.
-and uses `Travis <https://travis-ci.org/claws/aioprometheus>`_ for
+and uses `GitHub Actions <https://github.com/claws/aioprometheus/actions>`_ for
 Continuous Integration.
 
 If you have found a bug or have an idea for an enhancement that would
@@ -77,6 +77,17 @@ code style compliance.
     (aioprom) $ make style
 
 
+Linting
+-------
+
+This project uses Pylint to perform static analysis. A Makefile convenience
+rule is available to check linting.
+
+.. code-block:: console
+
+    (aioprom) $ make check-lint
+
+
 Type Annotations
 ----------------
 
@@ -85,16 +96,11 @@ that can improve code comprehension which can help with future enhancements.
 
 The type annotations checker ``mypy`` should run cleanly with no warnings.
 
-.. note::
-
-    There is still some work required to get mypy to run without warnings.
-    Until this rule is passing cleanly it can be ignored.
-
 Use the Makefile convenience rule to check no issues are reported.
 
 .. code-block:: console
 
-    (aioprom) $ make check_types
+    (aioprom) $ make check-types
 
 
 Test
@@ -147,13 +153,12 @@ a new set of `sphinx <http://sphinx-doc.org/>`_ html content.
 
     (aioprom) $ make docs
 
-To view the rendered docs locally as you are working you can use the simple
-Python web server.
+To view the rendered docs locally run the ``serve-docs`` rule from the top level
+directory to start a simple Python web server.
 
 .. code-block:: console
 
-    (aioprom) $ cd docs
-    (aioprom) $ python -m http.server
+    (aioprom) $ make serve-docs
 
 Then open a browser to the `docs <http://localhost:8000/_build/html/index.html>`_
 content.
@@ -196,13 +201,13 @@ The following steps are used to make a new software release:
 
   .. code-block:: console
 
-      (aioprom) $ make dist.test
+      (aioprom) $ make test-dist
 
 - Upload to PyPI using
 
   .. code-block:: console
 
-      (aioprom) $ make dist.upload
+      (aioprom) $ make upload-dist
 
 - Create and push a repo tag to Github.
 

--- a/examples/app-example.py
+++ b/examples/app-example.py
@@ -12,14 +12,13 @@ import logging
 import random
 import socket
 import uuid
-from asyncio.base_events import BaseEventLoop
 
 import psutil
 
-from aioprometheus import Counter, Gauge, Histogram, Service, Summary, formats
+from aioprometheus import Counter, Gauge, Histogram, Service, Summary
 
 
-class ExampleApp(object):
+class ExampleApp:
     """
     An example application that demonstrates how ``aioprometheus`` can be
     integrated and used within a Python application built upon asyncio.
@@ -41,12 +40,10 @@ class ExampleApp(object):
         self,
         metrics_host="127.0.0.1",
         metrics_port: int = 5000,
-        loop: BaseEventLoop = None,
     ):
 
         self.metrics_host = metrics_host
         self.metrics_port = metrics_port
-        self.loop = loop or asyncio.get_event_loop()
         self.timer = None  # type: asyncio.Handle
 
         ######################################################################
@@ -104,13 +101,13 @@ class ExampleApp(object):
     async def start(self):
         """Start the application"""
         await self.msvr.start(addr=self.metrics_host, port=self.metrics_port)
-        logger.debug("Serving prometheus metrics on: %s", self.msvr.metrics_url)
+        logger.debug(f"Serving prometheus metrics on: {self.msvr.metrics_url}")
 
         # Schedule a timer to update internal metrics. In a realistic
         # application metrics would be updated as needed. In this example
         # application a simple timer is used to emulate things happening,
         # which conveniently allows all metrics to be updated at once.
-        self.timer = self.loop.call_later(1.0, self.on_timer_expiry)
+        self.timer = asyncio.get_event_loop().call_later(1.0, self.on_timer_expiry)
 
     async def stop(self):
         """Stop the application"""
@@ -140,7 +137,7 @@ class ExampleApp(object):
         self.latency_metric.add({"path": "/data"}, random.random() * 5)
 
         # re-schedule another metrics update
-        self.timer = self.loop.call_later(1.0, self.on_timer_expiry)
+        self.timer = asyncio.get_event_loop().call_later(1.0, self.on_timer_expiry)
 
 
 if __name__ == "__main__":

--- a/examples/decorator_count_exceptions.py
+++ b/examples/decorator_count_exceptions.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
 
-    svr = Service(loop=loop)
+    svr = Service()
     svr.register(REQUESTS)
 
     try:

--- a/examples/decorator_inprogress.py
+++ b/examples/decorator_inprogress.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
 
-    svr = Service(loop=loop)
+    svr = Service()
     svr.register(REQUESTS)
 
     try:

--- a/examples/decorator_timer.py
+++ b/examples/decorator_timer.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
     loop = asyncio.get_event_loop()
 
-    svr = Service(loop=loop)
+    svr = Service()
     svr.register(REQUEST_TIME)
 
     try:

--- a/examples/frameworks/aiohttp-example.py
+++ b/examples/frameworks/aiohttp-example.py
@@ -28,7 +28,9 @@ app.events_counter = Counter("events", "Number of events.")
 app.registry.register(app.events_counter)
 
 
-async def handle_root(request):
+async def handle_root(
+    request,  # pylint: disable=unused-argument
+):
     app.events_counter.inc({"path": "/"})
     text = "Hello aiohttp"
     return web.Response(text=text)

--- a/examples/frameworks/fastapi_example.py
+++ b/examples/frameworks/fastapi_example.py
@@ -19,23 +19,23 @@ Run:
 
 from typing import List
 
-from fastapi import FastAPI, Header, Response
+from fastapi import FastAPI, Header, Request, Response
 
 from aioprometheus import Counter, Registry, render
 
 app = FastAPI()
-app.registry = Registry()
-app.events_counter = Counter("events", "Number of events.")
-app.registry.register(app.events_counter)
+app.state.registry = Registry()
+app.state.events_counter = Counter("events", "Number of events.")
+app.state.registry.register(app.state.events_counter)
 
 
 @app.get("/")
-async def hello():
-    app.events_counter.inc({"path": "/"})
+async def hello(request: Request):
+    request.app.state.events_counter.inc({"path": "/"})
     return "hello"
 
 
 @app.get("/metrics")
-async def handle_metrics(response: Response, accept: List[str] = Header(None)):
-    content, http_headers = render(app.registry, accept)
+async def handle_metrics(request: Request, accept: List[str] = Header(None)):
+    content, http_headers = render(request.app.state.registry, accept)
     return Response(content=content, media_type=http_headers["Content-Type"])

--- a/examples/metrics-fetcher.py
+++ b/examples/metrics-fetcher.py
@@ -16,7 +16,6 @@ import argparse
 import asyncio
 import logging
 import random
-from asyncio.base_events import BaseEventLoop
 
 import aiohttp
 import prometheus_metrics_proto
@@ -27,13 +26,15 @@ import aioprometheus
 TEXT = "text"
 BINARY = "binary"
 header_kinds = {
-    TEXT: aioprometheus.formats.TEXT_CONTENT_TYPE,  # 'text/plain',
-    BINARY: aioprometheus.formats.BINARY_CONTENT_TYPE,
+    TEXT: aioprometheus.formats.text.TEXT_CONTENT_TYPE,
+    BINARY: aioprometheus.formats.binary.BINARY_CONTENT_TYPE,
 }
 
 
 async def fetch_metrics(
-    url: str, fmt: str = None, interval: float = 1.0, loop: BaseEventLoop = None
+    url: str,
+    fmt: str = None,
+    interval: float = 1.0,
 ):
     """Fetch metrics from the service endpoint using different formats.
 
@@ -53,8 +54,8 @@ async def fetch_metrics(
             assert resp.status == 200
             content = await resp.read()
             content_type = resp.headers.get(CONTENT_TYPE)
-            print("Content-Type: {}".format(content_type))
-            print("size: {}".format(len(content)))
+            print(f"Content-Type: {content_type}")
+            print(f"size: {len(content)}")
             if choice == "text":
                 print(content.decode())
             else:
@@ -63,11 +64,11 @@ async def fetch_metrics(
                 print(prometheus_metrics_proto.decode(content))
 
     # schedule another fetch
-    loop.call_later(interval, fetch_task, url, fmt, interval, loop)
+    asyncio.get_event_loop().call_later(interval, fetch_task, url, fmt, interval)
 
 
-def fetch_task(url, fmt, interval, loop):
-    asyncio.ensure_future(fetch_metrics(url, fmt, interval, loop))
+def fetch_task(url, fmt, interval):
+    asyncio.ensure_future(fetch_metrics(url, fmt, interval))
 
 
 if __name__ == "__main__":
@@ -101,9 +102,7 @@ if __name__ == "__main__":
     loop = asyncio.get_event_loop()
 
     # create a task to fetch metrics at a periodic interval
-    loop.call_later(
-        args.interval, fetch_task, args.url, args.format, args.interval, loop
-    )
+    loop.call_later(args.interval, fetch_task, args.url, args.format, args.interval)
 
     try:
         loop.run_forever()

--- a/examples/simple-example.py
+++ b/examples/simple-example.py
@@ -19,14 +19,14 @@ from aioprometheus import Counter, Service
 
 if __name__ == "__main__":
 
-    async def main(svr: Service) -> None:
+    async def main(svc: Service) -> None:
 
         events_counter = Counter(
             "events", "Number of events.", const_labels={"host": socket.gethostname()}
         )
-        svr.register(events_counter)
-        await svr.start(addr="127.0.0.1", port=5000)
-        print(f"Serving prometheus metrics on: {svr.metrics_url}")
+        svc.register(events_counter)
+        await svc.start(addr="127.0.0.1", port=5000)
+        print(f"Serving prometheus metrics on: {svc.metrics_url}")
 
         # Now start another coroutine to periodically update a metric to
         # simulate the application making some progress.
@@ -38,11 +38,11 @@ if __name__ == "__main__":
         await updater(events_counter)
 
     loop = asyncio.get_event_loop()
-    svr = Service()
+    service = Service()
     try:
-        loop.run_until_complete(main(svr))
+        loop.run_until_complete(main(service))
     except KeyboardInterrupt:
         pass
     finally:
-        loop.run_until_complete(svr.stop())
+        loop.run_until_complete(service.stop())
     loop.close()

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,6 +4,7 @@ sphinx
 coverage
 isort[requirements_deprecated_finder]
 mypy
+pylint
 twine
 wheel
 

--- a/setup.py
+++ b/setup.py
@@ -9,21 +9,21 @@ regexp = re.compile(r'.*__version__ = [\'\"](.*?)[\'\"]', re.S)
 
 init_file = os.path.join(
     os.path.dirname(__file__), 'src', 'aioprometheus', '__init__.py')
-with open(init_file, 'r') as f:
+with open(init_file, 'rt') as f:  # pylint: disable=unspecified-encoding
     module_content = f.read()
     match = regexp.match(module_content)
     if match:
         version = match.group(1)
     else:
         raise RuntimeError(
-            'Cannot find __version__ in {}'.format(init_file))
+            f"Cannot find __version__ in {init_file}")
 
-with open('README.rst', 'r') as f:
+with open('README.rst', 'rt') as f:  # pylint: disable=unspecified-encoding
     readme = f.read()
 
 def parse_requirements(filename):
     ''' Load requirements from a pip requirements file '''
-    with open(filename, 'r') as fd:
+    with open(filename, 'rt') as fd:  # pylint: disable=unspecified-encoding
         lines = []
         for line in fd:
             line = line.strip()

--- a/src/aioprometheus/__init__.py
+++ b/src/aioprometheus/__init__.py
@@ -6,4 +6,4 @@ from .registry import CollectorRegistry, Registry
 from .renderer import render
 from .service import Service
 
-__version__ = "21.7.0"
+__version__ = "21.8.0"

--- a/src/aioprometheus/decorators.py
+++ b/src/aioprometheus/decorators.py
@@ -24,9 +24,7 @@ def timer(metric: Summary, labels: Dict[str, str] = None) -> Callable[..., Any]:
       be awaitable if the wrapped function was a coroutine function.
     """
     if not isinstance(metric, Summary):
-        raise Exception(
-            "timer decorator expects a Summary metric but got: {}".format(metric)
-        )
+        raise Exception(f"timer decorator expects a Summary metric but got: {metric}")
 
     def measure(func):
         """
@@ -79,9 +77,7 @@ def inprogress(metric: Gauge, labels: Dict[str, str] = None) -> Callable[..., An
       be awaitable if the wrapped function was a coroutine function.
     """
     if not isinstance(metric, Gauge):
-        raise Exception(
-            "inprogess decorator expects a Gauge metric but got: {}".format(metric)
-        )
+        raise Exception(f"inprogess decorator expects a Gauge metric but got: {metric}")
 
     def track(func):
         """
@@ -137,9 +133,7 @@ def count_exceptions(
     """
     if not isinstance(metric, Counter):
         raise Exception(
-            "count_exceptions decorator expects a Counter metric but got: {}".format(
-                metric
-            )
+            f"count_exceptions decorator expects a Counter metric but got: {metric}"
         )
 
     def track(func):

--- a/src/aioprometheus/formats/__init__.py
+++ b/src/aioprometheus/formats/__init__.py
@@ -1,7 +1,8 @@
+""" This sub-package implements metrics formatters """
 from . import text
 from .base import IFormatter
 
 try:
     from . import binary
 except ImportError:
-    binary = None
+    binary = None  # type: ignore

--- a/src/aioprometheus/formats/base.py
+++ b/src/aioprometheus/formats/base.py
@@ -1,18 +1,16 @@
 import abc
 import collections
 import datetime
-from typing import Dict
 
-# typing aliases
-LabelsType = Dict[str, str]
+from .mypy_types import LabelsType
 
 
 class IFormatter(abc.ABC):
-    """Formatter interface"""
+    """Metrics formatter interface"""
 
     @abc.abstractmethod
     def get_headers(self):
-        """Returns a dict of headers for this response format"""
+        """Returns a dict of HTTP headers for this response format"""
 
     @abc.abstractmethod
     def _format_counter(self, counter, name, const_labels):
@@ -81,8 +79,12 @@ class IFormatter(abc.ABC):
         are sorted by key.
 
         :param labels: a dict of labels for a metric.
+
         :param const_labels: a dict of constant labels to be associated with
           the metric.
+
+        :param ordered: A boolean that determines whether the metrics are
+          sorted alphabetically. Default value is False.
         """
         if const_labels:
             result = const_labels.copy()

--- a/src/aioprometheus/formats/binary.py
+++ b/src/aioprometheus/formats/binary.py
@@ -3,26 +3,24 @@ This module implements a formatter that emits metrics in a binary (Google
 Protocol Buffers) format.
 """
 
-from typing import Callable, Dict, List, Tuple, Union, cast
+# imports only used for type annotations
+from typing import Callable, List, Optional, cast
 
 import prometheus_metrics_proto as pmp
 
-# imports only used for type annotations
+from aioprometheus.collectors import Counter, Gauge, Histogram, Summary
 from aioprometheus.registry import CollectorRegistry
 
-from ..collectors import Counter, Gauge, Histogram, Summary
 from .base import IFormatter
+from .mypy_types import (
+    CollectorsType,
+    HistogramDictType,
+    LabelsType,
+    MetricTupleType,
+    SummaryDictType,
+)
 
 # typing aliases
-LabelsType = Dict[str, str]
-NumericValueType = Union[int, float]
-SummaryDictKeyType = Union[float, str]  # e.g. sum, 0.25, etc
-SummaryDictType = Dict[SummaryDictKeyType, NumericValueType]
-HistogramDictKeyType = Union[float, str]  # e.g. sum, 0.25, etc
-HistogramDictType = Dict[HistogramDictKeyType, NumericValueType]
-CollectorsType = Union[Counter, Gauge, Histogram, Summary]
-MetricValueType = Union[float, SummaryDictType, HistogramDictType]
-MetricTupleType = Tuple[LabelsType, MetricValueType]
 FormatterFuncType = Callable[[MetricTupleType, str, LabelsType], pmp.Metric]
 
 
@@ -43,10 +41,10 @@ class BinaryFormatter(IFormatter):
           to metric.
         """
         self.timestamp = timestamp
-        self._headers = {"Content-Type": BINARY_CONTENT_TYPE}
 
-    def get_headers(self) -> Dict[str, str]:
-        return self._headers
+    def get_headers(self) -> LabelsType:
+        """Returns a dict of HTTP headers for this response format"""
+        return {"Content-Type": BINARY_CONTENT_TYPE}
 
     def _format_counter(
         self, counter: MetricTupleType, name: str, const_labels: LabelsType
@@ -155,7 +153,7 @@ class BinaryFormatter(IFormatter):
 
         :return: a :class:`MetricFamily` object
         """
-        exec_method = None  # type: FormatterFuncType
+        exec_method = None  # type: Optional[FormatterFuncType]
         if isinstance(collector, Counter):
             metric_type = pmp.COUNTER
             exec_method = self._format_counter

--- a/src/aioprometheus/formats/mypy_types.py
+++ b/src/aioprometheus/formats/mypy_types.py
@@ -1,0 +1,18 @@
+"""
+This module holds common formatter type annotations.
+"""
+
+from typing import Dict, Tuple, Union
+
+from aioprometheus.collectors import Counter, Gauge, Histogram, Summary
+
+LabelsType = Dict[str, str]
+NumericValueType = Union[int, float]
+# ValueType = Union[str, NumericValueType]
+SummaryDictKeyType = Union[float, str]  # e.g. sum, 0.25, etc
+SummaryDictType = Dict[SummaryDictKeyType, NumericValueType]
+HistogramDictKeyType = Union[float, str]  # e.g. sum, 0.25, etc
+HistogramDictType = Dict[HistogramDictKeyType, NumericValueType]
+CollectorsType = Union[Counter, Gauge, Histogram, Summary]
+MetricValueType = Union[NumericValueType, SummaryDictType, HistogramDictType]
+MetricTupleType = Tuple[LabelsType, MetricValueType]

--- a/src/aioprometheus/histogram.py
+++ b/src/aioprometheus/histogram.py
@@ -48,7 +48,7 @@ def exponentialBuckets(
     return [start * (i * factor) for i in range(count)]
 
 
-class Histogram(object):
+class Histogram:
     """
     A Histogram counts individual observations from an event into configurable
     buckets. This histogram implementation also provides a sum and count of

--- a/src/aioprometheus/metricdict.py
+++ b/src/aioprometheus/metricdict.py
@@ -1,10 +1,6 @@
 import json
 import re
-
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import MutableMapping
+from collections.abc import MutableMapping
 
 # Sometimes python will access by string for example iterating objects, and
 # it has this notation
@@ -21,7 +17,7 @@ class MetricDict(MutableMapping):
     EMPTY_KEY = "__EMPTY__"
 
     def __init__(self, *args, **kwargs):
-        self.store = dict()
+        self.store = {}
         self.update(dict(*args, **kwargs))
 
     def __getitem__(self, key):
@@ -47,10 +43,10 @@ class MetricDict(MutableMapping):
 
         # Python accesses by string key so we allow if is str and
         # 'our custom' format
-        if type(key) == str and regex.match(key):
+        if isinstance(key, str) and regex.match(key):
             return key
 
-        if type(key) is not dict:
+        if not isinstance(key, dict):
             raise TypeError("Only accepts dicts as keys")
 
         return json.dumps(key, sort_keys=True)

--- a/src/aioprometheus/negotiator.py
+++ b/src/aioprometheus/negotiator.py
@@ -1,12 +1,12 @@
 import logging
-from typing import Callable, Sequence, Set
+from typing import Sequence, Set, Type
 
 from . import formats
 
 logger = logging.getLogger(__name__)
 
 # type aliases
-FormatterType = Callable[[bool], formats.IFormatter]
+FormatterType = Type[formats.IFormatter]
 
 
 def negotiate(accepts_headers: Sequence[str]) -> FormatterType:
@@ -22,7 +22,7 @@ def negotiate(accepts_headers: Sequence[str]) -> FormatterType:
     """
     accepts = parse_accepts(accepts_headers)
 
-    formatter = formats.text.TextFormatter  # type: formats.text.FormatterType
+    formatter = formats.text.TextFormatter  # type: FormatterType
 
     if formats.binary is not None:
         if formats.binary.BINARY_ACCEPTS.issubset(accepts):
@@ -36,10 +36,10 @@ def negotiate(accepts_headers: Sequence[str]) -> FormatterType:
 def parse_accepts(accept_headers: Sequence[str]) -> Set[str]:
     """Return a sequence of accepts items in the request headers"""
     accepts = set()  # type: Set[str]
-    for accept_items in accept_headers:
-        if ";" in accept_items:
-            accept_items = [i.strip() for i in accept_items.split(";")]
+    for accept_header in accept_headers:
+        if ";" in accept_header:
+            accept_items = [i.strip() for i in accept_header.split(";")]
         else:
-            accept_items = [accept_items]
+            accept_items = [accept_header]
         accepts.update(accept_items)
     return accepts

--- a/src/aioprometheus/registry.py
+++ b/src/aioprometheus/registry.py
@@ -5,7 +5,7 @@ from .collectors import Collector, Counter, Gauge, Histogram, Summary
 CollectorsType = Union[Counter, Gauge, Histogram, Summary]
 
 
-class CollectorRegistry(object):
+class CollectorRegistry:
     """This class implements the metrics collector registry.
 
     Collectors in the registry must comply with the Collector interface
@@ -30,12 +30,10 @@ class CollectorRegistry(object):
         :raises: ValueError if collector is already registered.
         """
         if not isinstance(collector, Collector):
-            raise TypeError("Invalid collector type: {}".format(collector))
+            raise TypeError(f"Invalid collector type: {collector}")
 
         if collector.name in self.collectors:
-            raise ValueError(
-                "Collector {} is already registered".format(collector.name)
-            )
+            raise ValueError(f"Collector {collector.name} is already registered")
 
         self.collectors[collector.name] = collector
 

--- a/src/aioprometheus/renderer.py
+++ b/src/aioprometheus/renderer.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Tuple
 
 from .formats import IFormatter
 from .negotiator import negotiate

--- a/tests/test_metricdict.py
+++ b/tests/test_metricdict.py
@@ -86,7 +86,7 @@ class TestMetricDict(unittest.TestCase):
         # Access ok but wrong key by order
         with self.assertRaises(KeyError) as context:
             metrics[bad_access_key]
-        self.assertEqual("'{0}'".format(bad_access_key), str(context.exception))
+        self.assertEqual(f"'{bad_access_key}'", str(context.exception))
 
     def test_empty_key(self):
         metrics = MetricDict()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -71,7 +71,7 @@ class TestCollectorDict(unittest.TestCase):
             del self.data["name"]
             self.c = Collector(**self.data)
 
-        self.assertEqual(
+        self.assertIn(
             "__init__() missing 1 required positional argument: 'name'",
             str(context.exception),
         )
@@ -81,7 +81,7 @@ class TestCollectorDict(unittest.TestCase):
             del self.data["doc"]
             self.c = Collector(**self.data)
 
-        self.assertEqual(
+        self.assertIn(
             "__init__() missing 1 required positional argument: 'doc'",
             str(context.exception),
         )

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -39,7 +39,7 @@ class TestPusherServer(object):
         _details = self._site._server.sockets[0].getsockname()
         _host, _port = _details[0:2]
         self.port = _port
-        self.url = "http://{host}:{port}".format(host=addr, port=_port)
+        self.url = f"http://{addr}:{_port}"
         # TODO: replace the above with url = self._site.name when aiohttp
         # issue #3018 is resolved.
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -33,8 +33,9 @@ class TestRegistry(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             r.register(Collector(**self.data))
 
+        collector_name = self.data["name"]
         self.assertEqual(
-            "Collector {} is already registered".format(self.data["name"]),
+            f"Collector {collector_name} is already registered",
             str(context.exception),
         )
 


### PR DESCRIPTION
This merge request addresses #52 by updating the source code and tooling to support linting and type annotation checking in CI.

- Many files are touched to satisfy the Mypy type annotations checker but no major functionality should be changed. 
- Some minor API changes were made such as removing need to supply the event loop parameter to classes. This behaviour has not been encouraged for some time.
- Version was bumped 21.8.0 due to these minor API changes.

- Source code modified to:
  - Support running run type annotations checks cleanly
  - Add a new module ``mypy_types.py`` that holds commonly used formatter type annotations
  - Support running linting checks cleanly

- Update Actions CI workflow to:
  - Add type annotations checks to CI
  - Add linting checks to CI

- Update developer docs to mention use of GitHub Actions, linting and type checking.

- Fix coverage output to report the same file path irrespective of whether package is installed normally or with a developer ``-e`` install.

- Update CI pip installation to use ``--use-feature=in-tree-build `` to avoid pip deprecation warning

- A few minor updates to support Python 3.10.

- Consistent use of f-strings.
