### PR TITLE
Add ASGI middleware support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Python Package Workflow
+name: CI Pipeline
 
 on:
   push:
@@ -39,9 +39,17 @@ jobs:
     - name: Check code style
       run: |
         make check-style
-    - name: Install package
+    - name: Install package on Python 3.6
+      # Quart is not supported on Python 3.6
+      if: ${{ matrix.python-version == '3.6' }}
       run: |
-        pip install .[aiohttp,binary] --use-feature=in-tree-build
+        echo "Python version is: ${{ matrix.python-version }}"
+        pip install .[aiohttp,binary,starlette] --use-feature=in-tree-build
+    - name: Install package
+      if: ${{ matrix.python-version != '3.6' }}
+      run: |
+        echo "Python version is: ${{ matrix.python-version }}"
+        pip install .[aiohttp,binary,starlette,quart] --use-feature=in-tree-build
     - name: Run unit tests
       run: |
         make test

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 build:
   image: latest
 python:
-  version: 3.6
+  version: 3.9
   pip_install: true
 formats: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,6 @@
 - Updated documentation to improve clarity and to use the sphinx_material theme.
 
 - Improved test coverage. Removed unused code.
+
+- Updated unit tests to gracefully handle when optional extras are not installed.
+  This specifically helps run tests on Python 3.6 where Quart is not supported.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This makefile has been created to help developers perform common actions.
 # It assumes it is operating in an environment, such as a virtual env,
-# where the python command links to the Python3.6 executable.
+# where the python command links to the Python3.7 executable.
 
 
 # Do not remove this block. It is used by the 'help' rule when
@@ -9,8 +9,7 @@
 # help: aioprometheus Makefile help
 # help:
 
-VENVS_DIR := $(HOME)/.venvs
-VENV_DIR := $(VENVS_DIR)/vap
+VENV_DIR := venv
 
 # help: help                    - display this makefile's help information
 .PHONY: help
@@ -21,11 +20,10 @@ help:
 # help: venv                    - create a virtual environment for development
 .PHONY: venv
 venv:
-	@test -d "$(VENVS_DIR)" || mkdir -p "$(VENVS_DIR)"
 	@rm -Rf "$(VENV_DIR)"
 	@python3 -m venv "$(VENV_DIR)"
 	@/bin/bash -c "source $(VENV_DIR)/bin/activate && pip install pip --upgrade && pip install -r requirements.dev.txt"
-	@/bin/bash -c "source $(VENV_DIR)/bin/activate && pip install -e ."
+	@/bin/bash -c "source $(VENV_DIR)/bin/activate && pip install -e .[aiohttp,binary,starlette,quart]"
 	@echo "Enter virtual environment using:\n\n\t$ source $(VENV_DIR)/bin/activate\n"
 
 

--- a/README.rst
+++ b/README.rst
@@ -1,25 +1,16 @@
-.. image:: https://github.com/claws/aioprometheus/workflows/Python%20Package%20Workflow/badge.svg?branch=master
-    :target: https://github.com/claws/aioprometheus/actions?query=branch%3Amaster
-
-.. image:: https://img.shields.io/pypi/v/aioprometheus.svg
-    :target: https://pypi.python.org/pypi/aioprometheus
-
-.. image:: https://readthedocs.org/projects/aioprometheus/badge/?version=latest
-    :target: https://aioprometheus.readthedocs.io/en/latest
-
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-  :target: https://github.com/ambv/black
-
 aioprometheus
 =============
+
+|ci status| |pypi| |python| |docs| |license|
 
 `aioprometheus` is a Prometheus Python client library for asyncio-based
 applications. It provides metrics collection and serving capabilities for
 use with Prometheus and compatible monitoring systems. It supports exporting
 metrics into text and binary formats and pushing metrics to a gateway.
 
-`aioprometheus` can be used in applications built with FastAPI/Starlette,
-Quart, aiohttp as well as networking apps built upon asyncio.
+The ASGI middleware in `aioprometheus` can be used in FastAPI/Starlette and
+Quart applications. `aioprometheus` can also be used in other kinds of asyncio
+applications too.
 
 The project documentation can be found on
 `ReadTheDocs <http://aioprometheus.readthedocs.org/>`_.
@@ -32,9 +23,28 @@ Install
 
     $ pip install aioprometheus
 
+The ASGI middleware does not have any external dependencies but the Starlette
+and Quart convenience functions that handle metrics requests do.
+
+If you plan on using the ASGI middleware in a Starlette / FastAPI application
+then you can install the extra dependencies alongside `aioprometheus` by adding
+extras to the install.
+
+.. code-block:: console
+
+    $ pip install aioprometheus[starlette]
+
+If you plan on using the ASGI middleware in a Quart application then you can
+install the extra dependencies alongside `aioprometheus` by adding extras
+to the install.
+
+.. code-block:: console
+
+    $ pip install aioprometheus[quart]
+
 A Prometheus Push Gateway client and a HTTP service are included, but their
 dependencies are not installed by default. You can install them alongside
-`aioprometheus` by adding optional extras to the install.
+`aioprometheus` by adding extras to the install.
 
 .. code-block:: console
 
@@ -53,7 +63,7 @@ Multiple optional dependencies can be listed at once, such as:
 
 .. code-block:: console
 
-    $ pip install aioprometheus[aiohttp,binary]
+    $ pip install aioprometheus[aiohttp,binary,starlette,quart]
 
 
 Usage
@@ -91,55 +101,59 @@ expose them to Prometheus or a compatible metrics collector. There are
 multiple strategies available for this and the right choice depends on the
 kind of thing being instrumented.
 
-An example showing how aioprometheus can be used within a FastAPI app to
-export metrics is shown below.
+If you are instrumenting a Starlette, FastAPI or Quart application then the
+easiest option for adding Prometheus metrics is to use the ASGI Middleware
+provided by `aioprometheus`.
+
+The ASGI middleware provides a default set of metrics that include counters
+for total requests received, total responses sent, exceptions raised and
+response status codes for route handlers.
+
+The example below shows how to use the aioprometheus ASGI middleware in a
+FastAPI application. FastAPI is built upon Starlette so using the middleware
+in Starlette would be the same.
 
 .. code-block:: python
 
-    """
-    This example uses adds some simple Prometheus instrumentation to a FastAPI
-    application. In this example a counter metric is instantiated and gets
-    updated whenever the "/" route is accessed. A '/metrics' route is added to
-    the application using the standard web framework method. The metrics route
-    renders Prometheus metrics from the default collector registry into the
-    appropriate format.
+    from fastapi import FastAPI, Request, Response
 
-    Run:
-
-    (venv) $ pip install fastapi uvicorn
-    (venv) $ python fastapi_example.py
-
-    """
-
-    from typing import List
-
-    from fastapi import FastAPI, Header, Request, Response
-
-    from aioprometheus import Counter, REGISTRY, render
-
+    from aioprometheus import Counter, MetricsMiddleware
+    from aioprometheus.asgi.starlette import metrics
 
     app = FastAPI()
-    app.state.events_counter = Counter("events", "Number of events.")
+
+    # Any custom application metrics are automatically included in the exposed
+    # metrics. It is a good idea to attach the metrics to 'app.state' so they
+    # can easily be accessed in the route handler - as metrics are often
+    # created in a different module than where they are used.
+    app.state.users_events_counter = Counter("events", "Number of events.")
+
+    app.add_middleware(MetricsMiddleware)
+    app.add_route("/metrics", metrics)
 
 
     @app.get("/")
-    async def hello(request: Request):
-        request.app.state.events_counter.inc({"path": "/"})
-        return "FastAPI Hello"
+    async def root(request: Request):
+        return Response("FastAPI Middleware Example")
 
 
-    @app.get("/metrics")
-    async def handle_metrics(request: Request, accept: List[str] = Header(None)):
-        content, http_headers = render(REGISTRY, accept)
-        return Response(content=content, media_type=http_headers["Content-Type"])
+    @app.get("/users/{user_id}")
+    async def get_user(
+        request: Request,
+        user_id: str,
+    ):
+        request.app.state.users_events_counter.inc({"path": request.scope["path"]})
+        return Response(f"{user_id}")
 
 
     if __name__ == "__main__":
         import uvicorn
+
         uvicorn.run(app)
 
-Examples in the ``examples/frameworks`` directory show how aioprometheus can
-be used within various web application frameworks.
+
+Other examples in the ``examples/frameworks`` directory show how aioprometheus
+can be used within various web application frameworks.
 
 The next example shows how to use the Service HTTP endpoint to provide a
 dedicated metrics endpoint for other applications such as long running
@@ -230,3 +244,19 @@ License
 was released under the MIT license. `aioprometheus` continues to use the MIT
 license and contains a copy of the original MIT license from the
 `prometheus-python` project as instructed by the original license.
+
+
+.. |ci status| image:: https://github.com/claws/aioprometheus/workflows/CI%20Pipeline/badge.svg?branch=master
+    :target: https://github.com/claws/aioprometheus/actions?query=branch%3Amaster
+
+.. |pypi| image:: https://img.shields.io/pypi/v/aioprometheus.svg
+    :target: https://pypi.python.org/pypi/aioprometheus
+
+.. |python| image:: https://img.shields.io/pypi/pyversions/aioprometheus.svg
+   :target: https://pypi.python.org/pypi/aioprometheus/
+
+.. |docs| image:: https://readthedocs.org/projects/aioprometheus/badge/?version=latest
+    :target: https://aioprometheus.readthedocs.io/en/latest
+
+.. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg
+   :target: https://github.com/claws/aioprometheus/License/LICENSE

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,17 +1,7 @@
-.. image:: https://github.com/claws/aioprometheus/workflows/Python%20Package%20Workflow/badge.svg?branch=master
-    :target: https://github.com/claws/aioprometheus/actions?query=branch%3Amaster
-
-.. image:: https://img.shields.io/pypi/v/aioprometheus.svg
-    :target: https://pypi.python.org/pypi/aioprometheus
-
-.. image:: https://readthedocs.org/projects/aioprometheus/badge/?version=latest
-    :target: https://aioprometheus.readthedocs.io/en/latest
-
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-  :target: https://github.com/ambv/black
-
 aioprometheus
 =============
+
+|ci status| |pypi| |python| |docs| |license|
 
 .. toctree::
    :maxdepth: 1
@@ -36,23 +26,36 @@ use this package.
 License
 -------
 
-`aioprometheus` is released under the MIT license.
-
-`aioprometheus` originates from the (now deprecated)
-`prometheus python <https://github.com/slok/prometheus-python>`_ package which
-was released under the MIT license. `aioprometheus` continues to use the MIT
-license and contains a copy of the orignal MIT license from the
-`prometheus-python` project as instructed by the original license.
+`aioprometheus` is released under the MIT license. It is based upon the (now
+deprecated) `prometheus python <https://github.com/slok/prometheus-python>`_
+package which was released under the MIT license. A copy of the original MIT
+license from the `prometheus-python` project is included as instructed by the
+original license.
 
 
 Origins
 -------
 
-`aioprometheus` originates from the (now deprecated)
-`prometheus python <https://github.com/slok/prometheus-python>`_ package.
-Many thanks to `slok <https://github.com/slok>`_ for developing
-prometheus-python. I have taken the original work and modified it to meet
-the needs of my asyncio-based applications, added the histogram metric,
-integrated support for binary format, updated and extended tests, added docs,
-decorators, etc.
+`aioprometheus` originates from the (now deprecated) `prometheus python`
+package. Many thanks to `slok <https://github.com/slok>`_ for developing
+`prometheus-python`.
 
+The original work has been modified and updated it to meet the needs of asyncio
+applications by adding the histogram metric, binary format support, docs,
+decorators, ASGI middleware, etc.
+
+
+.. |ci status| image:: https://github.com/claws/aioprometheus/workflows/CI%20Pipeline/badge.svg?branch=master
+    :target: https://github.com/claws/aioprometheus/actions?query=branch%3Amaster
+
+.. |pypi| image:: https://img.shields.io/pypi/v/aioprometheus.svg
+    :target: https://pypi.python.org/pypi/aioprometheus
+
+.. |python| image:: https://img.shields.io/pypi/pyversions/aioprometheus.svg
+   :target: https://pypi.python.org/pypi/aioprometheus/
+
+.. |docs| image:: https://readthedocs.org/projects/aioprometheus/badge/?version=latest
+    :target: https://aioprometheus.readthedocs.io/en/latest
+
+.. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg
+   :target: https://github.com/claws/aioprometheus/License/LICENSE

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -13,6 +13,26 @@ to install it.
 
     $ pip install aioprometheus
 
+
+The ASGI middleware does not have any external dependencies but the Starlette
+and Quart convenience functions that handle metrics requests do.
+
+If you plan on using the ASGI middleware in a Starlette / FastAPI application
+then you can install the extra dependencies alongside `aioprometheus` by adding
+extras to the install.
+
+.. code-block:: console
+
+    $ pip install aioprometheus[starlette]
+
+If you plan on using the ASGI middleware in a Quart application then you can
+install the extra dependencies alongside `aioprometheus` by adding extras
+to the install.
+
+.. code-block:: console
+
+    $ pip install aioprometheus[quart]
+
 A Prometheus Push Gateway client and a HTTP service are included, but their
 dependencies are not installed by default. You can install them alongside
 `aioprometheus` by adding optional extras to the install.
@@ -34,7 +54,7 @@ Multiple optional dependencies can be listed at once, such as:
 
 .. code-block:: console
 
-    $ pip install aioprometheus[aiohttp,binary]
+    $ pip install aioprometheus[aiohttp,binary,starlette,quart]
 
 
 .. _usage-label:
@@ -298,10 +318,45 @@ Web Frameworks
 The aioprometheus package can be used within web application frameworks
 such as ``Starlette``, ``FastAPI``, ``aiohttp`` and ``Quart``.
 
-An example showing how aioprometheus can be used with FastAPI is shown
-below.
+The easiest option for adding Prometheus metrics to a Starlette, FastAPI
+or Quart application is to use the ASGI Middleware provided by `aioprometheus`.
 
-.. literalinclude:: ../../examples/frameworks/fastapi_example.py
+The ASGI middleware provides a default set of metrics that include counters
+for total requests received, total responses sent, exceptions raised and
+response status codes for route handlers.
+
+The middleware excludes a set of common paths such as '/favicon.ico',
+'/metrics' and some others from triggering updates to the default metrics.
+The complete set is defined in ``aioprometheus.agsi.middleware.EXCLUDE_PATHS``.
+
+Any custom application metrics are automatically included in the exposed
+metrics.
+
+The example below shows how to use the aioprometheus ASGI middleware in a
+FastAPI application. FastAPI is built upon Starlette so using the middleware
+in Starlette would be the same.
+
+.. literalinclude:: ../../examples/frameworks/fastapi-middleware.py
+    :language: python3
+
+The example imports a Starlette specific metrics rendering function from the
+``aioprometheus.asgi.starlette`` module and attaches it to the '/metrics'
+route. The rendering function requires Starlette so remember to install
+aioprometheus with the 'starlette' extras.
+
+.. code-block:: console
+
+    $ pip install aioprometheus[starlette]
+
+Alternatively, if you don't want the default metrics provided by the ASGI
+middleware or want finer control over the metrics export function then you
+can use the aioprometheus render function to help implement your own
+metrics handler.
+
+The example below shows how this approach can be implemented with a FastAPI
+application.
+
+.. literalinclude:: ../../examples/frameworks/fastapi-example.py
     :language: python3
 
 There are more examples in the ``examples/frameworks`` directory showing

--- a/examples/frameworks/fastapi-example.py
+++ b/examples/frameworks/fastapi-example.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 """
-This example uses adds some simple Prometheus instrumentation to a FastAPI
-application. In this example a counter metric is instantiated and gets
-updated whenever the "/" route is accessed. A '/metrics' route is added to
+This example adds Prometheus metrics to a FastAPI application. In this
+example a counter metric is instantiated and gets updated whenever the "/"
+route is accessed.
+
+A '/metrics' route is implemented using the render function and added to
 the application using the standard web framework method. The metrics route
 renders Prometheus metrics from the default collector registry into the
 appropriate format.
@@ -10,7 +12,7 @@ appropriate format.
 Run:
 
   (venv) $ pip install fastapi uvicorn
-  (venv) $ python fastapi_example.py
+  (venv) $ python fastapi-example.py
 
 """
 

--- a/examples/frameworks/fastapi-middleware.py
+++ b/examples/frameworks/fastapi-middleware.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""
+This example shows how to use the aioprometheus ASGI middleware in a FastAPI
+application. FastAPI is built upon Starlette so using the middleware in
+Starlette would be the same.
+
+Run:
+
+  (venv) $ pip install fastapi uvicorn
+  (venv) $ python fastapi-middleware.py
+
+"""
+
+from fastapi import FastAPI, Request, Response
+
+from aioprometheus import Counter, MetricsMiddleware
+from aioprometheus.asgi.starlette import metrics
+
+app = FastAPI()
+
+# Any custom application metrics are automatically included in the exposed
+# metrics. It is a good idea to attach the metrics to 'app.state' so they
+# can easily be accessed in the route handler - as metrics are often
+# created in a different module than where they are used.
+app.state.users_events_counter = Counter("events", "Number of events.")
+
+app.add_middleware(MetricsMiddleware)
+app.add_route("/metrics", metrics)
+
+
+@app.get("/")
+async def root(request: Request):  # pylint: disable=unused-argument
+    return Response("FastAPI Middleware Example")
+
+
+@app.get("/users/{user_id}")
+async def get_user(
+    request: Request,
+    user_id: str,
+):
+    request.app.state.users_events_counter.inc({"path": request.scope["path"]})
+    return Response(f"{user_id}")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app)

--- a/examples/frameworks/quart-middleware.py
+++ b/examples/frameworks/quart-middleware.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""
+This example shows how to use the aioprometheus ASGI middleware in a Quart
+application.
+
+Run:
+
+  (venv) $ pip install quart
+  (venv) $ python quart_middleware.py
+
+"""
+
+from quart import Quart, request
+
+from aioprometheus import Counter, MetricsMiddleware
+from aioprometheus.asgi.quart import metrics
+
+app = Quart(__name__, static_folder=None)
+
+# Any custom application metrics are automatically included in the exposed
+# metrics. It is a good idea to attach the metrics to 'app.state' so they
+# can easily be accessed in the route handler - as metrics are often
+# created in a different module than where they are used.
+app.users_events_counter = Counter("events", "Number of events.")
+
+# Following Quart advice for Middleware, it is recommended to assign to and
+# wrap the asgi_app attribute when adding Middleware.
+app.asgi_app = MetricsMiddleware(app.asgi_app)
+app.add_url_rule("/metrics", "metrics", metrics, methods=["GET"])
+
+
+@app.route("/")
+async def root():
+    return "Quart Middleware Example"
+
+
+@app.route("/users/<user_id>")
+async def get_user(user_id):
+    app.users_events_counter.inc({"path": request.path})
+    return f"{user_id}"
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -9,11 +9,11 @@ pylint
 twine
 wheel
 
-# web app frameworks are used in unit tests to verify integration
+# web app frameworks are used in ASGI middleware and unit tests to verify integration
 aiohttp
 fastapi
 uvicorn
-quart
+quart; python_version > '3.7'
 
 # psutil is used in example code
 psutil

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import find_packages, setup
 
 regexp = re.compile(r'.*__version__ = [\'\"](.*?)[\'\"]', re.S)
 
-
 init_file = os.path.join(
     os.path.dirname(__file__), 'src', 'aioprometheus', '__init__.py')
 with open(init_file, 'rt') as f:  # pylint: disable=unspecified-encoding
@@ -48,15 +47,20 @@ if __name__ == "__main__":
         url="https://github.com/claws/aioprometheus",
         package_dir={'': 'src'},
         packages=find_packages('src'),
+        python_requires=">=3.6.0",
         install_requires=requirements,
         extras_require={
             "aiohttp": ["aiohttp>=3.3.2"],
             "binary": ["prometheus-metrics-proto>=18.1.1"],
+            "starlette": ["starlette>=0.14.2"],
+            "quart": ["quart>=0.15.1"],
         },
         classifiers=[
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",
             "License :: OSI Approved :: MIT License",
+            "Programming Language :: Python",
+            "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",

--- a/src/aioprometheus/__init__.py
+++ b/src/aioprometheus/__init__.py
@@ -3,6 +3,9 @@ from .decorators import count_exceptions, inprogress, timer
 from .negotiator import negotiate
 from .renderer import render
 
+# To avoid cicular imports issues asgi must be imported after other modules
+from .asgi.middleware import MetricsMiddleware  # isort:skip
+
 # The 'pusher' and 'service'  modules must be explicitly imported by package
 # users as they depend on optional extras.
 

--- a/src/aioprometheus/asgi/middleware.py
+++ b/src/aioprometheus/asgi/middleware.py
@@ -1,0 +1,167 @@
+from typing import Any, Awaitable, Callable, Dict, Sequence
+
+from aioprometheus import REGISTRY, Counter, Registry
+
+Scope = Dict[str, Any]
+Message = Dict[str, Any]
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+ASGICallable = Callable[[Scope, Receive, Send], Awaitable[None]]
+
+
+EXCLUDE_PATHS = (
+    "/metrics",
+    "/docs",
+    "/openapi.json",
+    "/docs/oauth2-redirect",
+    "/redoc",
+    "/favicon.ico",
+)
+
+
+class MetricsMiddleware:
+    """This class implements a Prometheus metrics collection middleware for
+    ASGI applications.
+
+    The default metrics provided by this middleware include counters for
+    requests received, responses sent, exceptions raised and status codes
+    for route handlers.
+
+    :param app: An ASGI callable. This callable represents the next ASGI
+      callable in the chain which might be the application or another
+      middleware.
+
+    :param registry: A collector registry to use when rendering metrics. If
+      not specified then the default registry will be used.
+
+    :param exclude_paths: A list of urls that should not trigger updates to
+      the default metrics.
+
+    :param use_template_urls: A boolean that defines whether route template
+      URLs should be used by the default route monitoring metrics. Template
+      URLs will report '/users/{user_id}' instead of '/users/bob' or
+      '/users/alice', etc. The template URLS can be more useful than the
+      actual route url as they allow the route handler to be easily
+      identified. This feature is only supported with Starlette / FastAPI
+      currently.
+    """
+
+    def __init__(
+        self,
+        app: ASGICallable,
+        registry: Registry = REGISTRY,
+        exclude_paths: Sequence[str] = EXCLUDE_PATHS,
+        use_template_urls: bool = True,
+    ) -> None:
+        # The 'app' argument really represents an ASGI framework callable.
+        self.asgi_callable = app
+
+        # Starlette applications add a reference to the ASGI app in the
+        # lifespan start scope. Save a reference to the ASGI app to assist
+        # later when extracting route templates. Only Starlette/FastAPI
+        # apps provide this feature.
+        self.starlette_app = None
+
+        self.exclude_paths = exclude_paths if exclude_paths else []
+        self.use_template_urls = use_template_urls
+
+        if registry is not None and not isinstance(registry, Registry):
+            raise Exception(f"registry must be a Registry, got: {type(registry)}")
+        self.registry = registry
+
+        # Create default metrics
+
+        self.requests_counter = Counter(
+            "requests_total_counter", "Total requests by method and path"
+        )
+
+        self.responses_counter = Counter(
+            "responses_total_counter", "Total responses by method and path"
+        )
+
+        self.exceptions_counter = Counter(
+            "exceptions_total_counter", "Total exceptions by method and path"
+        )
+
+        self.status_codes_counter = Counter(
+            "status_codes_counter",
+            "Total count of response status codes by method and path",
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+
+        if scope["type"] == "lifespan":
+            # Starlette adds a reference to the app in the lifespan start
+            # scope. Store a reference to the app to assist later when
+            # extracting route templates.
+            self.starlette_app = scope.get("app")
+
+        if scope["type"] != "http":
+            await self.asgi_callable(scope, receive, send)
+            return
+
+        def wrapped_send(response):
+            """
+            Wrap the ASGI send function so that metrics collection can be finished.
+            """
+            # This function makes use of labels defined in the calling context.
+
+            if response["type"] == "http.response.start":
+                status_code_labels = labels.copy()
+                status_code_labels["status_code"] = response["status"]
+                self.status_codes_counter.inc(status_code_labels)
+                self.responses_counter.inc(labels)
+
+            return send(response)
+
+        # Store HTTP path and method attributes in a variable that can be used
+        # later in the send method to complete metrics updates.
+
+        method = scope["method"]
+        path = self.get_full_or_template_path(scope)
+
+        if path in self.exclude_paths:
+            await self.asgi_callable(scope, receive, send)
+            return
+
+        labels = dict(method=method, path=path)
+
+        self.requests_counter.inc(labels)
+        try:
+            await self.asgi_callable(scope, receive, wrapped_send)
+        except Exception:
+            self.exceptions_counter.inc(labels)
+
+            status_code_labels = labels.copy()
+            status_code_labels["status_code"] = 500
+            self.status_codes_counter.inc(status_code_labels)
+            self.responses_counter.inc(labels)
+
+            raise
+
+    def get_full_or_template_path(self, scope) -> str:
+        """
+        Using the route template url can be more insightful than the actual
+        route url so that the route handler function can be easily identified.
+
+        For example, seeing the path '/users/{user_id}' in metrics is often
+        better than every combination of '/users/bob', /users/alice', etc.
+
+        Obtaining the route template will be a unique procedure for each web
+        framework. This feature is currently only supported for Starlette
+        and FastAPI applications.
+        """
+        root_path = scope.get("root_path", "")
+        path = scope.get("path", "")
+        full_path = f"{root_path}{path}"
+
+        if self.use_template_urls:
+            if self.starlette_app:
+                # Extract the route template from Starlette / FastAPI apps
+                for route in self.starlette_app.routes:
+                    match, _child_scope = route.matches(scope)
+                    # Enum value 2 represents the route template Match.FULL
+                    if match.value == 2:
+                        return route.path
+
+        return full_path

--- a/src/aioprometheus/asgi/quart.py
+++ b/src/aioprometheus/asgi/quart.py
@@ -1,0 +1,15 @@
+from quart import current_app, request
+
+from aioprometheus import REGISTRY, render
+
+
+async def metrics():
+    """Render metrics into format specified by 'accept' header.
+
+    This function first attempts to retrieve the metrics Registry from
+    ``current_app`` in case the app is using a custom registry instead
+    of the default registry. If this fails then the default registry is used.
+    """
+    registry = current_app.registry if hasattr(current_app, "registry") else REGISTRY
+    content, http_headers = render(registry, request.headers.getlist("accept"))
+    return content, http_headers

--- a/src/aioprometheus/asgi/starlette.py
+++ b/src/aioprometheus/asgi/starlette.py
@@ -1,0 +1,20 @@
+from starlette.requests import Request
+from starlette.responses import Response
+
+from aioprometheus import REGISTRY, render
+
+
+async def metrics(request: Request) -> Response:
+    """Render metrics into format specified by 'accept' header.
+
+    This function first attempts to retrieve the metrics Registry from
+    ``request.app.state`` in case the app is using a custom registry instead
+    of the default registry. If this fails then the default registry is used.
+    """
+    registry = (
+        request.app.state.registry
+        if hasattr(request.app.state, "registry")
+        else REGISTRY
+    )
+    content, http_headers = render(registry, request.headers.getlist("Accept"))
+    return Response(content=content, media_type=http_headers["Content-Type"])

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1,31 +1,47 @@
-import aiohttp
-import aiohttp.hdrs
-import aiohttp.web
 import asynctest
 
-import aioprometheus
+from aioprometheus import REGISTRY, Counter, formats, render
+
+try:
+    import aiohttp
+    import aiohttp.hdrs
+    import aiohttp.web
+
+    have_aiohttp = True
+except ImportError:
+    have_aiohttp = False
+
+try:
+    import prometheus_metrics_proto as pmp
+
+    have_pmp = True
+except ImportError:
+    have_pmp = False
 
 
+@asynctest.skipUnless(have_aiohttp, "aiohttp library is not available")
 class TestAiohttpRender(asynctest.TestCase):
     """
     Test exposing Prometheus metrics from within a aiohttp existing web
     service without starting a separate Prometheus metrics server.
     """
 
-    async def test_render_in_aiohttp_app(self):
-        """check render usage in aiohttp app"""
+    def tearDown(self):
+        REGISTRY.clear()
+
+    async def test_text_render_in_aiohttp_app(self):
+        """check text render usage in aiohttp app"""
 
         app = aiohttp.web.Application()
-        app.registry = aioprometheus.Registry()
-        app.events_counter = aioprometheus.Counter("events", "Number of events.")
-        app.registry.register(app.events_counter)
+        app.registry = REGISTRY
+        app.events_counter = Counter("events", "Number of events.")
 
         async def index(request):
             app.events_counter.inc({"path": "/"})
             return aiohttp.web.Response(text="hello")
 
         async def handle_metrics(request):
-            content, http_headers = aioprometheus.render(
+            content, http_headers = render(
                 app.registry, request.headers.getall(aiohttp.hdrs.ACCEPT, [])
             )
             return aiohttp.web.Response(body=content, headers=http_headers)
@@ -60,7 +76,7 @@ class TestAiohttpRender(asynctest.TestCase):
             ) as response:
                 self.assertEqual(response.status, 200)
                 self.assertIn(
-                    aioprometheus.formats.text.TEXT_CONTENT_TYPE,
+                    formats.text.TEXT_CONTENT_TYPE,
                     response.headers.get("content-type"),
                 )
                 # content = await response.read()
@@ -71,20 +87,62 @@ class TestAiohttpRender(asynctest.TestCase):
             ) as response:
                 self.assertEqual(response.status, 200)
                 self.assertIn(
-                    aioprometheus.formats.text.TEXT_CONTENT_TYPE,
+                    formats.text.TEXT_CONTENT_TYPE,
                     response.headers.get("content-type"),
                 )
+
+        await runner.cleanup()
+
+    @asynctest.skipUnless(have_pmp, "prometheus_metrics_proto library is not available")
+    async def test_binary_render_in_aiohttp_app(self):
+        """check binary render usage in aiohttp app"""
+
+        app = aiohttp.web.Application()
+        app.registry = REGISTRY
+        app.events_counter = Counter("events", "Number of events.")
+
+        async def index(request):
+            app.events_counter.inc({"path": "/"})
+            return aiohttp.web.Response(text="hello")
+
+        async def handle_metrics(request):
+            content, http_headers = render(
+                app.registry, request.headers.getall(aiohttp.hdrs.ACCEPT, [])
+            )
+            return aiohttp.web.Response(body=content, headers=http_headers)
+
+        app.add_routes(
+            [aiohttp.web.get("/", index), aiohttp.web.get("/metrics", handle_metrics)]
+        )
+
+        runner = aiohttp.web.AppRunner(app)
+        await runner.setup()
+
+        site = aiohttp.web.TCPSite(runner, "127.0.0.1", 0, shutdown_timeout=1.0)
+        await site.start()
+
+        # Fetch ephemeral port that was bound.
+        # IPv4 address returns a 2-tuple, IPv6 returns a 4-tuple
+        host, port, *_ = runner.addresses[0]
+        host = host if ":" not in host else f"[{host}]"
+        url = f"http://{host}:{port}"
+        root_url = f"{url}/"
+        metrics_url = f"{url}/metrics"
+
+        async with aiohttp.ClientSession() as session:
+
+            # Access root to increment metric counter
+            async with session.get(root_url) as response:
+                self.assertEqual(response.status, 200)
 
             # Get binary format
             async with session.get(
                 metrics_url,
-                headers={
-                    aiohttp.hdrs.ACCEPT: aioprometheus.formats.binary.BINARY_CONTENT_TYPE
-                },
+                headers={aiohttp.hdrs.ACCEPT: formats.binary.BINARY_CONTENT_TYPE},
             ) as response:
                 self.assertEqual(response.status, 200)
                 self.assertIn(
-                    aioprometheus.formats.binary.BINARY_CONTENT_TYPE,
+                    formats.binary.BINARY_CONTENT_TYPE,
                     response.headers.get("content-type"),
                 )
 

--- a/tests/test_dist.bash
+++ b/tests/test_dist.bash
@@ -25,7 +25,7 @@ echo "Install test dependencies and extras to check integrations"
 pip install asynctest requests aiohttp fastapi quart
 
 echo "Installing $RELEASE_ARCHIVE"
-pip install $RELEASE_ARCHIVE[aiohttp,binary]
+pip install $RELEASE_ARCHIVE[aiohttp,binary,starlette,quart]
 
 echo "Running tests"
 cd ..

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,33 +1,37 @@
 import unittest
 from typing import List
 
-import aioprometheus
-from aioprometheus import REGISTRY, formats
+from aioprometheus import REGISTRY, Counter, MetricsMiddleware, formats, render
+from aioprometheus.asgi.starlette import metrics
 
 try:
-    from fastapi import FastAPI, Header, Response
+    from fastapi import FastAPI, Header, Request, Response
     from fastapi.testclient import TestClient
 
     have_fastapi = True
 except ImportError:
     have_fastapi = False
 
+try:
+    import prometheus_metrics_proto as pmp
+
+    have_pmp = True
+except ImportError:
+    have_pmp = False
+
 
 @unittest.skipUnless(have_fastapi, "FastAPI library is not available")
-class TestFastAPIRender(unittest.TestCase):
-    """
-    Test exposing Prometheus metrics from within an FastAPI existing web
-    service without starting a separate Prometheus metrics server.
-    """
+class TestFastAPIUsage(unittest.TestCase):
+    """Test exposing Prometheus metrics from within a FastAPI app"""
 
     def tearDown(self):
         REGISTRY.clear()
 
-    def test_render_in_fastapi_app(self):
-        """check render usage in FastAPI app"""
+    def test_render_text(self):
+        """check render text usage in FastAPI app"""
 
         app = FastAPI()
-        app.events_counter = aioprometheus.Counter("events", "Number of events.")
+        app.events_counter = Counter("events", "Number of events.")
 
         @app.get("/")
         async def hello():
@@ -36,7 +40,7 @@ class TestFastAPIRender(unittest.TestCase):
 
         @app.get("/metrics")
         async def handle_metrics(response: Response, accept: List[str] = Header(None)):
-            content, http_headers = aioprometheus.render(REGISTRY, accept)
+            content, http_headers = render(REGISTRY, accept)
             return Response(content=content, media_type=http_headers["Content-Type"])
 
         # The test client also starts the web service
@@ -62,6 +66,33 @@ class TestFastAPIRender(unittest.TestCase):
             response.headers.get("content-type"),
         )
 
+        # Check content
+        self.assertIn('events{path="/"} 1', response.text)
+
+    @unittest.skipUnless(have_pmp, "prometheus_metrics_proto library is not available")
+    def test_render_binary(self):
+        """check render binary usage in FastAPI app"""
+
+        app = FastAPI()
+        app.events_counter = Counter("events", "Number of events.")
+
+        @app.get("/")
+        async def hello():
+            app.events_counter.inc({"path": "/"})
+            return "hello"
+
+        @app.get("/metrics")
+        async def handle_metrics(response: Response, accept: List[str] = Header(None)):
+            content, http_headers = render(REGISTRY, accept)
+            return Response(content=content, media_type=http_headers["Content-Type"])
+
+        # The test client also starts the web service
+        test_client = TestClient(app)
+
+        # Access root to increment metric counter
+        response = test_client.get("/")
+        self.assertEqual(response.status_code, 200)
+
         # Get binary format
         response = test_client.get(
             "/metrics",
@@ -71,4 +102,229 @@ class TestFastAPIRender(unittest.TestCase):
         self.assertIn(
             formats.binary.BINARY_CONTENT_TYPE,
             response.headers.get("content-type"),
+        )
+
+        metrics = pmp.decode(response.content)
+        self.assertEqual(len(metrics), 1)
+        mf = metrics[0]
+        self.assertIsInstance(mf, pmp.MetricFamily)
+        self.assertEqual(mf.type, pmp.COUNTER)
+        self.assertEqual(len(mf.metric), 1)
+        self.assertEqual(mf.metric[0].counter.value, 1)
+        self.assertEqual(mf.metric[0].label[0].name, "path")
+        self.assertEqual(mf.metric[0].label[0].value, "/")
+
+    def test_asgi_middleware(self):
+        """check ASGI middleware usage in FastAPI app"""
+
+        app = FastAPI()
+
+        # Add a custom application metric so it can be checked in output
+        app.events_counter = Counter("events", "Number of events.")
+
+        @app.get("/")
+        async def hello():
+            app.events_counter.inc({"path": "/"})
+            return "hello"
+
+        # Add a template path so it can be checked in output
+        @app.get("/users/{user_id}")
+        async def get_user(user_id: str):
+            return f"{user_id}"
+
+        # Add a route that always generates an exception
+        @app.get("/boom")
+        async def hello():
+            raise Exception("Boom")
+
+        app.add_middleware(MetricsMiddleware)
+        app.add_route("/metrics", metrics)
+
+        # The test client also starts the web service
+        test_client = TestClient(app)
+
+        # The test client does not call the ASGI lifespan scope on the app
+        # so we need to manual set the starlette_app attribute on the middleware.
+        # The only way I can think of doing this is to walk over the middlewares.
+        # However the structure is difficult to walk over.
+        # 'sem' represents the ServerErrorMiddleware that Starlette always adds
+        # as the first Middlware, before any user middleware.
+        sem = app.middleware_stack
+        self.assertIsInstance(sem.app, MetricsMiddleware)
+        sem.app.starlette_app = app
+
+        # Access root to update default metrics and trigger custom metric update
+        response = test_client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+        # Access templated path
+        response = test_client.get("/users/bob")
+        self.assertEqual(response.status_code, 200)
+
+        # Get default format
+        response = test_client.get("/metrics", headers={"accept": "*/*"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            formats.text.TEXT_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )
+
+        # Check content
+        self.assertIn('events{path="/"} 1', response.text)
+
+        self.assertIn('requests_total_counter{method="GET",path="/"} 1', response.text)
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/",status_code="200"} 1',
+            response.text,
+        )
+        self.assertIn('responses_total_counter{method="GET",path="/"} 1', response.text)
+
+        self.assertIn(
+            'requests_total_counter{method="GET",path="/users/{user_id}"} 1',
+            response.text,
+        )
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/users/{user_id}",status_code="200"} 1',
+            response.text,
+        )
+        self.assertIn(
+            'responses_total_counter{method="GET",path="/users/{user_id}"} 1',
+            response.text,
+        )
+
+        # Access it again to confirm default metrics get incremented
+        response = test_client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+        # Access a different template path so we can confirm only the template
+        # path value gets incremented.
+        response = test_client.get("/users/alice")
+        self.assertEqual(response.status_code, 200)
+
+        # Get text format
+        response = test_client.get("/metrics", headers={"accept": "text/plain;"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            formats.text.TEXT_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )
+
+        # Check content
+        self.assertIn('events{path="/"} 2', response.text)
+
+        self.assertIn('requests_total_counter{method="GET",path="/"} 2', response.text)
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/",status_code="200"} 2',
+            response.text,
+        )
+        self.assertIn('responses_total_counter{method="GET",path="/"} 2', response.text)
+
+        self.assertIn(
+            'requests_total_counter{method="GET",path="/users/{user_id}"} 2',
+            response.text,
+        )
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/users/{user_id}",status_code="200"} 2',
+            response.text,
+        )
+        self.assertIn(
+            'responses_total_counter{method="GET",path="/users/{user_id}"} 2',
+            response.text,
+        )
+
+        # Confirm no exception have been observed so far.
+        self.assertNotIn("exceptions_total_counter{", response.text)
+
+        # Access boom route to trigger exception metric update
+        with self.assertRaises(Exception):
+            response = test_client.get("/boom")
+            self.assertEqual(response.status_code, 500)
+
+        response = test_client.get("/metrics", headers={"accept": "*/*"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            formats.text.TEXT_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )
+
+        # Check exception counter was incremented
+        self.assertIn(
+            'exceptions_total_counter{method="GET",path="/boom"} 1', response.text
+        )
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/boom",status_code="500"} 1',
+            response.text,
+        )
+
+    def test_asgi_middleware_template_path_disabled(self):
+        """check ASGI middleware template path usage in FastAPI app"""
+
+        app = FastAPI()
+
+        app.add_middleware(MetricsMiddleware, use_template_urls=False)
+        app.add_route("/metrics", metrics)
+
+        @app.get("/users/{user_id}")
+        async def get_user(user_id: str):
+            return f"{user_id}"
+
+        # The test client also starts the web service
+        test_client = TestClient(app)
+
+        # Access root to increment metric counter
+        response = test_client.get("/users/bob")
+        self.assertEqual(response.status_code, 200)
+
+        # Get default format
+        response = test_client.get("/metrics", headers={"accept": "*/*"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            formats.text.TEXT_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )
+
+        # Check content
+        self.assertIn(
+            'requests_total_counter{method="GET",path="/users/bob"} 1', response.text
+        )
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/users/bob",status_code="200"} 1',
+            response.text,
+        )
+        self.assertIn(
+            'responses_total_counter{method="GET",path="/users/bob"} 1', response.text
+        )
+
+        # Access it again to confirm default metrics get incremented
+        response = test_client.get("/users/alice")
+        self.assertEqual(response.status_code, 200)
+
+        # Get text format
+        response = test_client.get("/metrics", headers={"accept": "*/*"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            formats.text.TEXT_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )
+
+        # Check content
+        self.assertIn(
+            'requests_total_counter{method="GET",path="/users/bob"} 1', response.text
+        )
+        self.assertIn(
+            'requests_total_counter{method="GET",path="/users/alice"} 1', response.text
+        )
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/users/bob",status_code="200"} 1',
+            response.text,
+        )
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/users/alice",status_code="200"} 1',
+            response.text,
+        )
+        self.assertIn(
+            'responses_total_counter{method="GET",path="/users/bob"} 1', response.text
+        )
+        self.assertIn(
+            'responses_total_counter{method="GET",path="/users/alice"} 1', response.text
         )

--- a/tests/test_formats_binary.py
+++ b/tests/test_formats_binary.py
@@ -1,16 +1,21 @@
-import datetime
-import time
 import unittest
 import unittest.mock
 
-import prometheus_metrics_proto as pmp
-
 from aioprometheus import REGISTRY, Counter, Gauge, Histogram, Summary
-from aioprometheus.formats import binary
+
+try:
+    import prometheus_metrics_proto as pmp
+
+    from aioprometheus.formats import binary
+
+    have_pmp = True
+except ImportError:
+    have_pmp = False
 
 TEST_TIMESTAMP = 1515044377268
 
 
+@unittest.skipUnless(have_pmp, "prometheus_metrics_proto library is not available")
 class TestProtobufFormat(unittest.TestCase):
     def setUp(self):
 

--- a/tests/test_negotiate.py
+++ b/tests/test_negotiate.py
@@ -1,32 +1,19 @@
 import unittest
 
-from aioprometheus.formats import binary, text
+from aioprometheus.formats import text
 from aioprometheus.negotiator import negotiate
+
+try:
+    import prometheus_metrics_proto as pmp
+
+    from aioprometheus.formats import binary
+
+    have_pmp = True
+except ImportError:
+    have_pmp = False
 
 
 class TestNegotiate(unittest.TestCase):
-    def test_protobuffer(self):
-        """check that a protobuf formatter is returned"""
-        headers = (
-            "proto=io.prometheus.client.MetricFamily;application/vnd.google.protobuf;encoding=delimited",
-            "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited",
-            "encoding=delimited;application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily",
-        )
-
-        for accept in headers:
-            self.assertEqual(binary.BinaryFormatter, negotiate(set(accept.split(";"))))
-
-    def test_text_004(self):
-        """check that a text formatter is returned for version 0.0.4"""
-        headers = (
-            "text/plain; version=0.0.4",
-            "text/plain;version=0.0.4",
-            "version=0.0.4; text/plain",
-        )
-
-        for accept in headers:
-            self.assertEqual(text.TextFormatter, negotiate(set(accept.split(";"))))
-
     def test_text_default(self):
         """check that a text formatter is returned for plain text"""
         headers = ("text/plain;",)
@@ -41,7 +28,30 @@ class TestNegotiate(unittest.TestCase):
         for accept in headers:
             self.assertEqual(text.TextFormatter, negotiate(set(accept.split(";"))))
 
+    def test_text_004(self):
+        """check that a text formatter is returned for version 0.0.4"""
+        headers = (
+            "text/plain; version=0.0.4",
+            "text/plain;version=0.0.4",
+            "version=0.0.4; text/plain",
+        )
+
+        for accept in headers:
+            self.assertEqual(text.TextFormatter, negotiate(set(accept.split(";"))))
+
     def test_no_accept_header(self):
         """check request with no accept header works"""
         self.assertEqual(text.TextFormatter, negotiate(set()))
         self.assertEqual(text.TextFormatter, negotiate(set([""])))
+
+    @unittest.skipUnless(have_pmp, "prometheus_metrics_proto library is not available")
+    def test_protobuffer(self):
+        """check that a protobuf formatter is returned"""
+        headers = (
+            "proto=io.prometheus.client.MetricFamily;application/vnd.google.protobuf;encoding=delimited",
+            "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited",
+            "encoding=delimited;application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily",
+        )
+
+        for accept in headers:
+            self.assertEqual(binary.BinaryFormatter, negotiate(set(accept.split(";"))))

--- a/tests/test_quart.py
+++ b/tests/test_quart.py
@@ -2,10 +2,12 @@ import unittest
 
 import asynctest
 
-from aioprometheus import REGISTRY, Counter, formats, render
+from aioprometheus import REGISTRY, Counter, MetricsMiddleware, formats, render
 
 try:
     from quart import Quart, request
+
+    from aioprometheus.asgi.quart import metrics
 
     have_quart = True
 except ImportError:
@@ -14,10 +16,7 @@ except ImportError:
 
 @unittest.skipUnless(have_quart, "Quart library is not available")
 class TestQuartRender(asynctest.TestCase):
-    """
-    Test exposing Prometheus metrics from within an Quart existing web
-    service without starting a separate Prometheus metrics server.
-    """
+    """Test exposing Prometheus metrics from within a Quart app"""
 
     def tearDown(self):
         REGISTRY.clear()
@@ -72,3 +71,65 @@ class TestQuartRender(asynctest.TestCase):
             formats.binary.BINARY_CONTENT_TYPE,
             response.headers.get("content-type"),
         )
+
+    async def test_asgi_middleware(self):
+        """check ASGI middleware usage in Quart app"""
+
+        app = Quart(__name__)
+        app.events_counter = Counter("events", "Number of events.")
+
+        @app.route("/")
+        async def index():
+            app.events_counter.inc({"path": "/"})
+            return "hello"
+
+        app.asgi_app = MetricsMiddleware(app.asgi_app)
+        app.add_url_rule("/metrics", "metrics", metrics, methods=["GET"])
+
+        # The test client also starts the web service
+        test_client = app.test_client()
+
+        # Access root to increment metric counter
+        response = await test_client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+        # Get default format
+        response = await test_client.get("/metrics", headers={"accept": "*/*"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            formats.text.TEXT_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )
+        payload = await response.get_data()
+        content = payload.decode("utf-8")
+
+        # Check content
+        self.assertIn('events{path="/"} 1', content)
+        self.assertIn('requests_total_counter{method="GET",path="/"} 1', content)
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/",status_code="200"} 1', content
+        )
+        self.assertIn('responses_total_counter{method="GET",path="/"} 1', content)
+
+        # Access it again to confirm default metrics get incremented
+        response = await test_client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+        # Get text format
+        response = await test_client.get("/metrics", headers={"accept": "text/plain;"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            formats.text.TEXT_CONTENT_TYPE,
+            response.headers.get("content-type"),
+        )
+
+        payload = await response.get_data()
+        content = payload.decode("utf-8")
+
+        # Check content
+        self.assertIn('events{path="/"} 2', content)
+        self.assertIn('requests_total_counter{method="GET",path="/"} 2', content)
+        self.assertIn(
+            'status_codes_counter{method="GET",path="/",status_code="200"} 2', content
+        )
+        self.assertIn('responses_total_counter{method="GET",path="/"} 2', content)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -2,6 +2,13 @@ import asynctest
 
 from aioprometheus import REGISTRY, formats, render
 
+try:
+    import prometheus_metrics_proto as pmp
+
+    have_pmp = True
+except ImportError:
+    have_pmp = False
+
 
 class TestRenderer(asynctest.TestCase):
     async def test_invalid_registry(self):
@@ -30,6 +37,7 @@ class TestRenderer(asynctest.TestCase):
         content, http_headers = render(REGISTRY, accepts_headers)
         self.assertEqual(http_headers["Content-Type"], formats.text.TEXT_CONTENT_TYPE)
 
+    @asynctest.skipUnless(have_pmp, "prometheus_metrics_proto library is not available")
     async def test_render_binary(self):
         """check metrics can be rendered using binary format"""
         accepts_headers = (formats.binary.BINARY_CONTENT_TYPE,)


### PR DESCRIPTION
This change add an ASGI middleware to simplify use in Starlette, FastAPI and Quart web applications.

- Adds a asgi sub-package
- Updates unit tests
- Updates documentation
- Updates examples
- Updates README
- Adds new optional extra dependencies of ``starlette`` and ``quart``.
- Updates unit tests to gracefully handle when optional extras are not present.