### PR TITLE
Update CI to upload coverage data to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,16 @@ jobs:
       run: |
         make test
     - name: Check code coverage
+      if: ${{ matrix.python-version == '3.9' }}
       run: |
         make coverage
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      if: ${{ matrix.python-version == '3.9' }}
+      with:
+        fail_ci_if_error: false
     - name: Generate docs
+      if: ${{ matrix.python-version == '3.9' }}
       run: |
         make docs
     - name: Generate package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 21.9.X
+
+- Updated CI to support uploading code coverage results to CodeCov.
+  Updated documentation to display codecov status badge.
+
 ## 21.9.0
 
 - Streamline the aioprometheus API so that metrics are automatically registered

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ coverage:
 	@coverage combine
 	@coverage html
 	@coverage report
+	@coverage xml
 
 
 # help: style                   - perform code style format

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 aioprometheus
 =============
 
-|ci status| |pypi| |python| |docs| |license|
+|ci status| |pypi| |python| |cov| |docs| |license|
 
 `aioprometheus` is a Prometheus Python client library for asyncio-based
 applications. It provides metrics collection and serving capabilities for
@@ -253,10 +253,13 @@ license and contains a copy of the original MIT license from the
     :target: https://pypi.python.org/pypi/aioprometheus
 
 .. |python| image:: https://img.shields.io/pypi/pyversions/aioprometheus.svg
-   :target: https://pypi.python.org/pypi/aioprometheus/
+    :target: https://pypi.python.org/pypi/aioprometheus/
+
+.. |cov| image:: https://codecov.io/github/claws/aioprometheus/branch/master/graph/badge.svg?token=oPPBg8hBgc
+    :target: https://codecov.io/github/claws/aioprometheus
 
 .. |docs| image:: https://readthedocs.org/projects/aioprometheus/badge/?version=latest
     :target: https://aioprometheus.readthedocs.io/en/latest
 
 .. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg
-   :target: https://github.com/claws/aioprometheus/License/LICENSE
+    :target: https://github.com/claws/aioprometheus/License/LICENSE

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 aioprometheus
 =============
 
-|ci status| |pypi| |python| |docs| |license|
+|ci status| |pypi| |python| |cov| |docs| |license|
 
 .. toctree::
    :maxdepth: 1
@@ -52,10 +52,13 @@ decorators, ASGI middleware, etc.
     :target: https://pypi.python.org/pypi/aioprometheus
 
 .. |python| image:: https://img.shields.io/pypi/pyversions/aioprometheus.svg
-   :target: https://pypi.python.org/pypi/aioprometheus/
+    :target: https://pypi.python.org/pypi/aioprometheus/
+
+.. |cov| image:: https://codecov.io/github/claws/aioprometheus/branch/master/graph/badge.svg?token=oPPBg8hBgc
+    :target: https://codecov.io/github/claws/aioprometheus
 
 .. |docs| image:: https://readthedocs.org/projects/aioprometheus/badge/?version=latest
     :target: https://aioprometheus.readthedocs.io/en/latest
 
 .. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg
-   :target: https://github.com/claws/aioprometheus/License/LICENSE
+    :target: https://github.com/claws/aioprometheus/License/LICENSE


### PR DESCRIPTION
This change updates the CI pipeline to upload code coverage report to codecov which allows code coverage to be tracked over time.
Updated the Makefile 'coverage' rule to produce the XML data expected by the codecov uploader.
Updated docs to display a code coverage status badge provided by codecov.
