### PR TITLE
Fix Python version in ReadTheDocs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 build:
   image: latest
 python:
-  version: 3.9
+  version: 3.8
   pip_install: true
 formats: []


### PR DESCRIPTION
RTD reports an error as it only supports python versions up to 3.8.