### PR TITLE
Update RTD config to version 2 format

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,10 @@
+version: 2
 build:
   image: latest
 python:
-  version: 3.8
-  pip_install: true
+  version: "3.8"
+  install:
+    - requirements: requirements.dev.txt
+    - method: pip
+      path: .
 formats: []


### PR DESCRIPTION
Update the RTD configuration file to v2.
List the development requirements file so that RTD installs those items which should allow the build to complete as sphinx_material will then be found.