### PR TITLE
Use specified registry in middleware collectors

### DIFF
--- a/examples/service/app-service-example.py
+++ b/examples/service/app-service-example.py
@@ -118,7 +118,7 @@ class ExampleApp:
         self.requests_metric.inc({"path": "/"})
 
         # Monitor request payload data to emulate webserver app
-        self.payload_metric.add({"path": "/data"}, random.random() * 2 ** 10)
+        self.payload_metric.add({"path": "/data"}, random.random() * 2**10)
 
         # Monitor request latency to emulate webserver app
         self.latency_metric.add({"path": "/data"}, random.random() * 5)

--- a/src/aioprometheus/asgi/middleware.py
+++ b/src/aioprometheus/asgi/middleware.py
@@ -80,21 +80,27 @@ class MetricsMiddleware:
         # Create default metrics
 
         self.requests_counter = Counter(
-            "requests_total_counter", "Total number of requests received"
+            "requests_total_counter",
+            "Total number of requests received",
+            registry=registry,
         )
 
         self.responses_counter = Counter(
-            "responses_total_counter", "Total number of responses sent"
+            "responses_total_counter",
+            "Total number of responses sent",
+            registry=registry,
         )
 
         self.exceptions_counter = Counter(
             "exceptions_total_counter",
             "Total number of requested which generated an exception",
+            registry=registry,
         )
 
         self.status_codes_counter = Counter(
             "status_codes_counter",
             "Total number of response status codes",
+            registry=registry,
         )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):

--- a/src/aioprometheus/histogram.py
+++ b/src/aioprometheus/histogram.py
@@ -45,7 +45,7 @@ def exponentialBuckets(
         raise Exception("Invalid start, must be positive")
     if factor < 1:
         raise Exception("Invalid factor, must be greater than one")
-    return [start * (factor ** i) for i in range(count)]
+    return [start * (factor**i) for i in range(count)]
 
 
 class Histogram:


### PR DESCRIPTION
The user-specified registry was not passed to the middleware collectors,
so the default registry was always used.

The user-specified registry is now passed to the collectors. If the user
does not specify a registry the default registry will be used.

Fixes #70 