### PR TITLE
Improve Starlette integration, fixes #72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## XX.Y.Z
 
+## 22.3.0
+
+- Minor tweaks to project files such as setup.py formatting, Makefile rule
+  streamlining, docs updates.
+
+- Improve ASGI middleware integration with Starlette. Due to a implementation
+  limitation the aioprometheus ASGI middleware needed to be added as the last
+  middleware to avoid triggering an exception when Starlette rebuilds the
+  middleware stack. To avoid this issue the middleware metrics are now all
+  created upon the first call to update a metric.
+
+- Fix ASGI middleware to allow a custom registry to be passed in.
+
+- Fix ASGI middleware to allow custom const_labels to be passed in.
+
 ## 21.9.1
 
 - Add Python 3.10 to CI testing.

--- a/docs/changes/index.rst
+++ b/docs/changes/index.rst
@@ -1,0 +1,5 @@
+Changes
+=======
+
+.. literalinclude:: ../../CHANGELOG.md
+    :language: markdown

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -114,19 +114,19 @@ tool which discovers all the unit tests and runs them.
 
     (aioprom) $ make test
 
-Or, you can call the standard library unittest module directly.
+To see more verbose test output run the verbose test rule.
 
 .. code-block:: console
 
-    (aioprom) $ python -m unittest discover -s tests -v
+    (aioprom) $ make test-verbose
 
-Individual unit tests can be run using the standard library ``unittest``
-package too.
+Individual unit tests can be run by calling them using the standard
+library ``unittest`` package.
 
 .. code-block:: console
 
     (aioprom) $ cd aioprometheus/tests
-    (aioprom) $ python -m unittest test_negotiate
+    (aioprom) $ python -m unittest test_negotiate.TestNegotiate.test_text_default
 
 
 Coverage
@@ -160,8 +160,7 @@ directory to start a simple Python web server.
 
     (aioprom) $ make serve-docs
 
-Then open a browser to the `docs <http://localhost:8000/_build/html/index.html>`_
-content.
+Then open a browser to the `docs <http://localhost:8000/>`_ content.
 
 
 .. _version-label:
@@ -180,13 +179,16 @@ will be incremented.
 Release Process
 ---------------
 
-Assuming that the tests are passing, the docs build without warnings and the
-type annotations check passes without warnings then a release can be made.
+The following steps are performed when making a new software release:
 
-The following steps are used to make a new software release:
+- Check that style, linting and type annotations checks pass without warnings.
 
-- Ensure that the version label in ``__init__.py`` is correct. It must comply
-  with the :ref:`version-label` scheme.
+- Check that docs build passes without errors or warnings.
+
+- Check that the version label in ``__init__.py`` has been updated for the
+  new release. It must comply with the  :ref:`version-label` scheme.
+
+- Update the CHANGELOG.md to describe the changes in this release.
 
 - Create the distribution. This project produces an artefact called a pure
   Python wheel. Only Python3 is supported by this package.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ aioprometheus
    user/index
    dev/index
    api/index
+   changes/index
 
 `aioprometheus` is a Prometheus Python client library for asyncio-based
 applications. It provides metrics collection and serving capabilities for

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -540,6 +540,6 @@ likely be necessary to clear the default registry between test runs to get
 it back to a clean state. Failing to do this will likely result in an error
 being raised reporting that a metric by the same name already exists.
 
-Reseting the deafult registry is easily achieved by calling
+Resetting the default registry is easily achieved by calling
 ``REGISTRY.clear()``. See the unit tests of this project for examples of
 where this is done.

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,28 @@
-
 import os
 import re
 
 from setuptools import find_packages, setup
 
-regexp = re.compile(r'.*__version__ = [\'\"](.*?)[\'\"]', re.S)
+regexp = re.compile(r".*__version__ = [\'\"](.*?)[\'\"]", re.S)
 
 init_file = os.path.join(
-    os.path.dirname(__file__), 'src', 'aioprometheus', '__init__.py')
-with open(init_file, 'rt') as f:  # pylint: disable=unspecified-encoding
+    os.path.dirname(__file__), "src", "aioprometheus", "__init__.py"
+)
+with open(init_file, "rt") as f:  # pylint: disable=unspecified-encoding
     module_content = f.read()
     match = regexp.match(module_content)
     if match:
         version = match.group(1)
     else:
-        raise RuntimeError(
-            f"Cannot find __version__ in {init_file}")
+        raise RuntimeError(f"Cannot find __version__ in {init_file}")
 
-with open('README.rst', 'rt') as f:  # pylint: disable=unspecified-encoding
+with open("README.rst", "rt") as f:  # pylint: disable=unspecified-encoding
     readme = f.read()
 
+
 def parse_requirements(filename):
-    ''' Load requirements from a pip requirements file '''
-    with open(filename, 'rt') as fd:  # pylint: disable=unspecified-encoding
+    """Load requirements from a pip requirements file"""
+    with open(filename, "rt") as fd:  # pylint: disable=unspecified-encoding
         lines = []
         for line in fd:
             line = line.strip()
@@ -30,7 +30,8 @@ def parse_requirements(filename):
                 lines.append(line)
     return lines
 
-requirements = parse_requirements('requirements.txt')
+
+requirements = parse_requirements("requirements.txt")
 
 
 if __name__ == "__main__":
@@ -45,10 +46,10 @@ if __name__ == "__main__":
         license="MIT",
         keywords=["prometheus", "monitoring", "metrics"],
         url="https://github.com/claws/aioprometheus",
-        package_dir={'': 'src'},
-        packages=find_packages('src'),
-        package_data = {
-            'aioprometheus': ['py.typed'],
+        package_dir={"": "src"},
+        packages=find_packages("src"),
+        package_data={
+            "aioprometheus": ["py.typed"],
         },
         python_requires=">=3.6.0",
         install_requires=requirements,
@@ -72,4 +73,5 @@ if __name__ == "__main__":
             "Topic :: Software Development :: Libraries :: Python Modules",
             "Topic :: System :: Monitoring",
             "Typing :: Typed",
-        ])
+        ],
+    )

--- a/src/aioprometheus/__init__.py
+++ b/src/aioprometheus/__init__.py
@@ -3,10 +3,10 @@ from .decorators import count_exceptions, inprogress, timer
 from .negotiator import negotiate
 from .renderer import render
 
-# To avoid cicular imports issues asgi must be imported after other modules
+# To avoid circular imports issues asgi must be imported after other modules
 from .asgi.middleware import MetricsMiddleware  # isort:skip
 
 # The 'pusher' and 'service'  modules must be explicitly imported by package
 # users as they depend on optional extras.
 
-__version__ = "21.9.1"
+__version__ = "22.3.0"


### PR DESCRIPTION
This change improves Starlette integration by fixing #72.

The change involves delaying creation of the middleware metrics until a call is made through to the middleware to update a  metric. This approached seemed like the best method for handling Starlette occasionally rebuilding the middleware stack - which, due to the middleware previously creating metrics in the ``__init__`` method, was the cause of the exceptions being triggered.

This change also makes minor tweaks to some project files and bumps the version in preparation for a new release. The tweaks are:
- include change log in docs.
- streamline Makefile rules
- Minor updates to dev docs
- include ``setup.py`` in style checks
- typos and grammar fixes
