### PR TITLE
#31 Adding support for aiohttp client args via pusher kwargs

### DIFF
--- a/src/aioprometheus/pusher.py
+++ b/src/aioprometheus/pusher.py
@@ -67,19 +67,23 @@ class Pusher:
 
         self.path = urljoin(self.addr, path)
 
-    async def add(self, registry: Registry = REGISTRY) -> "aiohttp.ClientResponse":
+    async def add(
+        self, registry: Registry = REGISTRY, **kwargs
+    ) -> "aiohttp.ClientResponse":
         """
         ``add`` works like replace, but only metrics with the same name as the
         newly pushed metrics are replaced.
         """
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(**kwargs) as session:
             payload = self.formatter.marshall(registry)
             async with session.post(
                 self.path, data=payload, headers=self.headers
             ) as resp:
                 return resp
 
-    async def replace(self, registry: Registry = REGISTRY) -> "aiohttp.ClientResponse":
+    async def replace(
+        self, registry: Registry = REGISTRY, **kwargs
+    ) -> "aiohttp.ClientResponse":
         """
         ``replace`` pushes new values for a group of metrics to the push
         gateway.
@@ -90,19 +94,21 @@ class Pusher:
             URL will be replaced with the new metrics value.
 
         """
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(**kwargs) as session:
             payload = self.formatter.marshall(registry)
             async with session.put(
                 self.path, data=payload, headers=self.headers
             ) as resp:
                 return resp
 
-    async def delete(self, registry: Registry = REGISTRY) -> "aiohttp.ClientResponse":
+    async def delete(
+        self, registry: Registry = REGISTRY, **kwargs
+    ) -> "aiohttp.ClientResponse":
         """
         ``delete`` deletes metrics from the push gateway. All metrics with
         the grouping key specified in the URL are deleted.
         """
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(**kwargs) as session:
             payload = self.formatter.marshall(registry)
             async with session.delete(
                 self.path, data=payload, headers=self.headers

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 import asynctest
 
@@ -273,6 +274,7 @@ class TestPusher(asynctest.TestCase):
         self.assertEqual("DELETE", self.server.test_results["method"])
         self.assertEqual(valid_result, self.server.test_results["body"])
 
+    @asynctest.skipUnless(sys.version_info > (3, 6, 0), "requires 3.7+")
     async def test_push_timeout(self):
         job_name = "my-job"
         p = Pusher(job_name, self.server.url, path="/slow")

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -274,7 +274,7 @@ class TestPusher(asynctest.TestCase):
         self.assertEqual("DELETE", self.server.test_results["method"])
         self.assertEqual(valid_result, self.server.test_results["body"])
 
-    @asynctest.skipUnless(sys.version_info > (3, 7, 0), "requires 3.7+")
+    @asynctest.skipUnless(sys.version_info > (3, 8, 0), "requires 3.8+")
     async def test_push_timeout(self):
         job_name = "my-job"
         p = Pusher(job_name, self.server.url, path="/slow")

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -257,3 +257,13 @@ class TestPusher(asynctest.TestCase):
         self.assertEqual("/metrics/job/my-job", self.server.test_results["path"])
         self.assertEqual("DELETE", self.server.test_results["method"])
         self.assertEqual(valid_result, self.server.test_results["body"])
+
+    async def test_push_delete(self):
+        job_name = "my-job"
+        p = Pusher(job_name, "http://localhost:2022")
+
+        counter = Counter("counter_test", "A counter.")
+        counter.inc({})
+
+        with self.assertRaises(aiohttp.client_exceptions.ClientConnectorError):
+            await p.replace(REGISTRY, timeout=aiohttp.ClientTimeout(total=60))

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -282,6 +282,12 @@ class TestPusher(asynctest.TestCase):
         counter = Counter("counter_test", "A counter.")
         counter.inc({})
 
+        try:
+            import asyncio.exceptions
+        except:
+            self.skipTest("requires python 3.8+")
+            return
+
         with self.assertRaises(asyncio.exceptions.TimeoutError):
             await p.delete(REGISTRY, timeout=aiohttp.ClientTimeout(total=1))
 

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -274,7 +274,7 @@ class TestPusher(asynctest.TestCase):
         self.assertEqual("DELETE", self.server.test_results["method"])
         self.assertEqual(valid_result, self.server.test_results["body"])
 
-    @asynctest.skipUnless(sys.version_info > (3, 6, 0), "requires 3.7+")
+    @asynctest.skipUnless(sys.version_info > (3, 7, 0), "requires 3.7+")
     async def test_push_timeout(self):
         job_name = "my-job"
         p = Pusher(job_name, self.server.url, path="/slow")

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -1,5 +1,7 @@
-import asynctest
 import asyncio
+
+import asynctest
+
 from aioprometheus import REGISTRY, Counter, Registry
 
 try:


### PR DESCRIPTION
This adds support for passing in auth or timeout arguments to aiohttp.