### PR TITLE
Use orjson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+orjson
 quantile-python >= 1.1

--- a/src/aioprometheus/metricdict.py
+++ b/src/aioprometheus/metricdict.py
@@ -1,6 +1,7 @@
-import json
 import re
 from collections.abc import MutableMapping
+
+import orjson
 
 # Sometimes python will access by string for example iterating objects, and
 # it has this notation
@@ -43,10 +44,12 @@ class MetricDict(MutableMapping):
 
         # Python accesses by string key so we allow if is str and
         # 'our custom' format
-        if isinstance(key, str) and regex.match(key):
+        if isinstance(key, bytes) and regex.match(key.decode()):
             return key
 
         if not isinstance(key, dict):
             raise TypeError("Only accepts dicts as keys")
 
-        return json.dumps(key, sort_keys=True)
+        return orjson.dumps(
+            key, option=(orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS)
+        )

--- a/tests/test_metricdict.py
+++ b/tests/test_metricdict.py
@@ -68,8 +68,8 @@ class TestMetricDict(unittest.TestCase):
 
     def test_access_by_str(self):
         label = {"b": 2, "c": 3, "a": 1}
-        access_key = '{"a": 1, "b": 2, "c": 3}'
-        bad_access_key = '{"b": 2, "c": 3, "a": 1}'
+        access_key = b'{"a":1,"b":2,"c":3}'
+        bad_access_key = b'{"b":2,"c":3,"a":1}'
         value = 100
 
         metrics = MetricDict()
@@ -86,7 +86,7 @@ class TestMetricDict(unittest.TestCase):
         # Access ok but wrong key by order
         with self.assertRaises(KeyError) as context:
             metrics[bad_access_key]
-        self.assertEqual(f"'{bad_access_key}'", str(context.exception))
+        self.assertEqual(f"{bad_access_key}", str(context.exception))
 
     def test_empty_key(self):
         metrics = MetricDict()


### PR DESCRIPTION
* Use orjson as its much faster than the standard python json library.
* Drop object_pairs_hook when decoding keys as orjson interface does not support it.

A simple benchmark (there are plenty of others available on the internet):
```
In [1]: import json, orjson

In [2]: test_dict = {'bfdfsd': 223, 'afdsfds': '1freresr', '1':4, '3': '434w3', 'gfdgd': 'trttdrfg' }

In [3]: timeit json.loads(json.dumps(test_dict, sort_keys=True))
4.98 µs ± 78.9 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [4]: timeit orjson.loads(orjson.dumps(test_dict, option=(orjson.OPT_SORT_KEYS|orjson.OPT_NON_STR_KEYS)))
778 ns ± 2.09 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [5]: timeit orjson.loads(orjson.dumps(test_dict, option=orjson.OPT_SORT_KEYS))
692 ns ± 13.9 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```