### PR TITLE
Add scheduled build and release prep

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,45 @@
+name: Scheduled Job
+
+on:
+  schedule:
+    # Run a job every month to verify dependencies continue to work as expected.
+    # This periodic pipeline catches things that change infrequently like API
+    # changes in pip and unpinned package dependencies.
+    #
+    # This job runs at 09:05 on the second day of each month
+    - cron: "5 9 2 * *"
+
+jobs:
+  scheduled-job:
+    name: "Scheduled job for Python ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          pip install -r requirements.dev.txt
+      - name: Check code style
+        run: |
+          make check-style
+      - name: Install package
+        run: |
+          echo "Python version is: ${{ matrix.python-version }}"
+          pip install .[aiohttp,starlette,quart]
+      - name: Run unit tests
+        run: |
+          make test
+      - name: Generate docs
+        run: |
+          make docs
+      - name: Generate package
+        run: |
+          make dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## XX.Y.Z
 
+## 22.5.0
+
+- Fix CI package install issue related to pip (#78)
+
+- Update Pusher to accept 'kwargs' to provide custom configuration to aiohttp
+  client (#75)
+
+- Use orjson instead of standard json to improve performance by speeding up
+  MetricDict (#77) when rendering.
+
+- Add a scheduled CI job to periodically verify unpinned dependencies (e.g. pip)
+  continue to work as expected.
+
+- Updated Quart unit test to fix issue which would result in a test failing if the
+  optional 'binary' package was not installed.
+
+- Update package version to 22.5.0
+
 ## 22.3.0
 
 - Minor tweaks to project files such as setup.py formatting, Makefile rule

--- a/tests/test_pusher.py
+++ b/tests/test_pusher.py
@@ -40,7 +40,7 @@ if have_aiohttp:
             return resp
 
         async def slow_handler(self, request):
-            await asyncio.sleep(5)
+            await asyncio.sleep(3)
             data = await request.read()
             self.test_results = {
                 "path": request.path,
@@ -288,14 +288,15 @@ class TestPusher(asynctest.TestCase):
             self.skipTest("requires python 3.8+")
             return
 
+        timeout = aiohttp.ClientTimeout(total=0.5)
         with self.assertRaises(asyncio.exceptions.TimeoutError):
-            await p.delete(REGISTRY, timeout=aiohttp.ClientTimeout(total=1))
+            await p.delete(REGISTRY, timeout=timeout)
 
         with self.assertRaises(asyncio.exceptions.TimeoutError):
-            await p.replace(REGISTRY, timeout=aiohttp.ClientTimeout(total=1))
+            await p.replace(REGISTRY, timeout=timeout)
 
         with self.assertRaises(asyncio.exceptions.TimeoutError):
-            await p.add(REGISTRY, timeout=aiohttp.ClientTimeout(total=1))
+            await p.add(REGISTRY, timeout=timeout)
 
         with self.assertRaises(asyncio.exceptions.TimeoutError):
-            await p.replace(REGISTRY, timeout=aiohttp.ClientTimeout(total=1))
+            await p.replace(REGISTRY, timeout=timeout)


### PR DESCRIPTION
Add a scheduled CI job to run periodically that should help identify when dependencies API's change.

Prepare for next release by updating change log, bumping version, fixing/updating some unit tests.

